### PR TITLE
SliceUnique: fix test line length errors reported by revive

### DIFF
--- a/slices_test.go
+++ b/slices_test.go
@@ -8,12 +8,15 @@ import (
 )
 
 var (
-	ints           = []int{74, 59, 238, -784, 9845, 959, 905, 0, 0, 42, 7586, -5467984, 7586}
-	expectInts     = []int{74, 59, 238, -784, 9845, 959, 905, 0, 42, 7586, -5467984}
-	float64s       = []float64{74.3, 59.0, math.Inf(1), 238.2, -784.0, 2.3, 7.8, 7.8, 74.3, 59.0, math.Inf(1), 238.2, -784.0, 2.3}
+	ints       = []int{74, 59, 238, -784, 9845, 959, 905, 0, 0, 42, 7586, -5467984, 7586}
+	expectInts = []int{74, 59, 238, -784, 9845, 959, 905, 0, 42, 7586, -5467984}
+
+	float64s = []float64{74.3, 59.0, math.Inf(1), 238.2, -784.0, 2.3, 7.8, 7.8, 74.3,
+		59.0, math.Inf(1), 238.2, -784.0, 2.3}
 	expectFloat64s = []float64{74.3, 59.0, math.Inf(1), 238.2, -784, 2.3, 7.8}
-	strs           = []string{"", "Hello", "foo", "bar", "foo", "f00", "%*&^*&^&"}
-	expectStrs     = []string{"", "Hello", "foo", "bar", "f00", "%*&^*&^&"}
+
+	strs       = []string{"", "Hello", "foo", "bar", "foo", "f00", "%*&^*&^&"}
+	expectStrs = []string{"", "Hello", "foo", "bar", "f00", "%*&^*&^&"}
 )
 
 func TestSliceUniqueInt(t *testing.T) {


### PR DESCRIPTION
I forgot we don't have CI integration and missed this from revive:

```
 ⚠  https://revive.run/r#line-length-limit  line is 130 characters, out of limit 100  
  slices_test.go:13:0
```