### PR TITLE
deprecate Wrapf(), and add common errors for errors.Is()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ should be on a subdirectory, it shouldn't be here.
 
 ## Errors
 
-* Wrap/Wrapf/Unwrappable
+* Wrap/Unwrappable
 * Errors/CompoundError
 * CoalesceError
 * AsRecovered/Recovered

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ should be on a subdirectory, it shouldn't be here.
 * AsRecovered/Recovered
 * Catcher
 * PanicError
-* Panic/Panicf/PanicWrap/PanicWrapf
+* Panic/Panicf/PanicWrap
 * WaitGroup
 * Frame/Stack
 * Here/StackFrame/StackTrace

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ should be on a subdirectory, it shouldn't be here.
 * Here/StackFrame/StackTrace
 * CallStacker
 
+* ErrNotImplemented
+* ErrExists/ErrNotExists
+* ErrInvalid/ErrUnknown
+
 ## See also
 
 * [darvaza.org/slog](https://pkg.go.dev/darvaza.org/slog)

--- a/errors.go
+++ b/errors.go
@@ -14,20 +14,19 @@ type Unwrappable interface {
 	Unwrap() error
 }
 
-// Wrapf annotates an error with a formatted string. if %w is used the argument
-// will be unwrapped
-func Wrapf(err error, format string, args ...any) error {
+// Wrap annotates an error, optionally with a formatted string.
+// if %w is used the argument will be unwrapped
+func Wrap(err error, format string, args ...any) error {
+	var note string
+
 	if err == nil {
 		return nil
 	}
 
-	return Wrap(err, fmt.Errorf(format, args...).Error())
-}
-
-// Wrap annotates an error with a string
-func Wrap(err error, note string) error {
-	if err == nil {
-		return nil
+	if len(args) > 0 {
+		note = fmt.Errorf(format, args...).Error()
+	} else {
+		note = format
 	}
 
 	if len(note) == 0 {

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,21 @@
 package core
 
 import (
+	"errors"
 	"fmt"
+)
+
+var (
+	// ErrNotImplemented indicates something hasn't been implemented yet
+	ErrNotImplemented = errors.New("not implemented")
+	// ErrExists indicates something already exists
+	ErrExists = errors.New("already exists")
+	// ErrNotExists indicates something doesn't exist
+	ErrNotExists = errors.New("does not exist")
+	// ErrInvalid indicates an argument isn't valid
+	ErrInvalid = errors.New("invalid argument")
+	// ErrUnknown indicates something isn't recognized
+	ErrUnknown = errors.New("unknown")
 )
 
 var (

--- a/panicerror.go
+++ b/panicerror.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -42,16 +43,27 @@ func (p *PanicError) CallStack() Stack {
 
 // NewPanicError creates a new PanicError with arbitrary payload
 func NewPanicError(skip int, payload any) *PanicError {
+	if s, ok := payload.(string); ok {
+		payload = errors.New(s)
+	}
 	return &PanicError{
 		payload: payload,
 		stack:   StackTrace(skip + 1),
 	}
 }
 
-// NewPanicErrorf creates a new PanicError with a formatted string as payload
+// NewPanicErrorf creates a new PanicError annotated with
+// a string, optionally formatted. %w is expanded.
 func NewPanicErrorf(skip int, format string, args ...any) *PanicError {
+	var payload error
+	if len(args) > 0 {
+		payload = fmt.Errorf(format, args...)
+	} else {
+		payload = errors.New(format)
+	}
+
 	return &PanicError{
-		payload: fmt.Errorf(format, args...),
+		payload: payload,
 		stack:   StackTrace(skip + 1),
 	}
 }

--- a/panicerror.go
+++ b/panicerror.go
@@ -57,17 +57,8 @@ func NewPanicErrorf(skip int, format string, args ...any) *PanicError {
 }
 
 // NewPanicWrap creates a new PanicError wrapping a given error
-// annotated with a string message
-func NewPanicWrap(skip int, err error, msg string) *PanicError {
-	return &PanicError{
-		payload: Wrap(err, msg),
-		stack:   StackTrace(skip + 1),
-	}
-}
-
-// NewPanicWrapf creates a new PanicError wrapping a given error
-// annotated with a formatted string
-func NewPanicWrapf(skip int, err error, format string, args ...any) *PanicError {
+// annotated, optionally formatted. %w is expanded.
+func NewPanicWrap(skip int, err error, format string, args ...any) *PanicError {
 	return &PanicError{
 		payload: Wrap(err, format, args...),
 		stack:   StackTrace(skip + 1),
@@ -84,12 +75,8 @@ func Panicf(format string, args ...any) {
 	panic(NewPanicErrorf(1, format, args...))
 }
 
-// PanicWrap emits a PanicError wrapping an annotated error
-func PanicWrap(err error, msg string) {
-	panic(NewPanicWrap(1, err, msg))
-}
-
-// PanicWrapf emits a PanicError wrapping an error annotated with a formatted string
-func PanicWrapf(err error, format string, args ...any) {
-	panic(NewPanicWrapf(1, err, format, args...))
+// PanicWrap emits a PanicError wrapping an annotated error, optionally
+// formatted. %w is expanded.
+func PanicWrap(err error, format string, args ...any) {
+	panic(NewPanicWrap(1, err, format, args...))
 }

--- a/panicerror.go
+++ b/panicerror.go
@@ -60,7 +60,7 @@ func NewPanicErrorf(skip int, format string, args ...any) *PanicError {
 // annotated with a string message
 func NewPanicWrap(skip int, err error, msg string) *PanicError {
 	return &PanicError{
-		payload: Wrapf(err, msg),
+		payload: Wrap(err, msg),
 		stack:   StackTrace(skip + 1),
 	}
 }
@@ -69,7 +69,7 @@ func NewPanicWrap(skip int, err error, msg string) *PanicError {
 // annotated with a formatted string
 func NewPanicWrapf(skip int, err error, format string, args ...any) *PanicError {
 	return &PanicError{
-		payload: Wrapf(err, format, args...),
+		payload: Wrap(err, format, args...),
 		stack:   StackTrace(skip + 1),
 	}
 }


### PR DESCRIPTION
* Wrapf() deprecated by Wrap() improvements
* PanicWrapf() deprecated by PanicWrap() improvements
* NewPanicWrapf() deprecated by NewPanicWrap() improvements
* NewPanicError() improved handling of strings
* Add common ErrFoo for errors.Is()
  * ErrNotImplemented
  * ErrExists/ErrNotExists
  * ErrInvalid/ErrUnknown