### PR TITLE
errors: Unwrap() and IsError/IsErrorFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ should be on a subdirectory, it shouldn't be here.
 
 ## Errors
 
-* Wrap/Unwrappable
+* Wrap/Unwrappable/Unwrap
 * Errors/CompoundError
 * CoalesceError
 * AsRecovered/Recovered

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ should be on a subdirectory, it shouldn't be here.
 * Wrap/Unwrappable/Unwrap
 * Errors/CompoundError
 * CoalesceError
+* IsError/IsErrorFn
 * AsRecovered/Recovered
 * Catcher
 * PanicError

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ should be on a subdirectory, it shouldn't be here.
 * Wrap/Unwrappable/Unwrap
 * Errors/CompoundError
 * CoalesceError
-* IsError/IsErrorFn
+* IsError/IsErrorFn/IsErrorFn2
 * AsRecovered/Recovered
 * Catcher
 * PanicError

--- a/compounderror.go
+++ b/compounderror.go
@@ -33,6 +33,11 @@ func (w *CompoundError) Errors() []error {
 	return w.Errs
 }
 
+// Unwrap returns the contained slice of errors
+func (w *CompoundError) Unwrap() []error {
+	return w.Errs
+}
+
 // Ok tells when there are no errors stored
 func (w *CompoundError) Ok() bool {
 	return len(w.Errs) == 0

--- a/errors.go
+++ b/errors.go
@@ -166,3 +166,37 @@ func IsErrorFn(check func(error) bool, errs ...error) bool {
 
 	return false
 }
+
+// IsErrorFn2 recursively checks if any of the given errors gets a
+// certain answer from the check function.
+// As opposed to IsErrorFn, IsErrorFn2 will stop when it has certainty
+// of a false result.
+//
+// revive:disable:cognitive-complexity
+func IsErrorFn2(check func(error) (bool, bool), errs ...error) (is bool, known bool) {
+	// revive:enable:cognitive-complexity
+	if check == nil || len(errs) == 0 {
+		return false, true
+	}
+
+	// direct match first
+	for _, e := range errs {
+		if e != nil {
+			if is, known = check(e); known {
+				return is, true
+			}
+		}
+	}
+
+	// and unwrapping
+	for _, e := range errs {
+		if errs := Unwrap(e); len(errs) > 0 {
+			if is, known = IsErrorFn2(check, errs...); known {
+				return is, true
+			}
+		}
+	}
+
+	// unknown
+	return false, false
+}


### PR DESCRIPTION
### **User description**
* Unwrap unwraps possibly-compound errors.
* IsError/IsErrorFn recursively checks an error
* IsErrorFn2 recursively checks an error but can stop on a false if well known


___

### **PR Type**
enhancement


___

### **Description**
- Introduced `Unwrap()` method in `CompoundError` to return internal errors directly.
- Implemented new functions in `errors.go`:
  - `Unwrap` to handle unwrapping of compound errors and filtering nils.
  - `IsError` to recursively check if an error matches any in a provided list.
  - `IsErrorFn` to apply a custom check function across potentially nested errors.
- Updated the README to include new error handling functionalities, enhancing documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compounderror.go</strong><dd><code>Add Unwrap method to CompoundError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
compounderror.go

<li>Added <code>Unwrap()</code> method to <code>CompoundError</code> to return the slice of errors <br>it contains.<br>


</details>
    

  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/54/files#diff-dd7600eec8481df6716e956d2869759e30487324cdd878d4f0ecb26f43f39e2c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>errors.go</strong><dd><code>Enhance error handling with new functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
errors.go

<li>Added <code>Unwrap</code> function to unwrap one layer of a compound error, <br>filtering out nil entries.<br> <li> Added <code>IsError</code> function to check recursively if an error is in a given <br>list.<br> <li> Added <code>IsErrorFn</code> function to check recursively if any error satisfies a <br>specified check function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/54/files#diff-76a7e0e299c7417bae32d3098e71370980157fe29e68a366671491d147d40572">+71/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect new error handling functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

<li>Updated the Errors section to include <code>Unwrap</code>, <code>IsError</code>, and <code>IsErrorFn</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/54/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

