### PR TITLE
errors: introduce QuietWrap() which won't expand the cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ should be on a subdirectory, it shouldn't be here.
 
 ## Errors
 
-* Wrap/Unwrappable/Unwrap
+* Wrap/QuietWrap/Unwrappable/Unwrap
 * Errors/CompoundError
 * CoalesceError
 * IsError/IsErrorFn/IsErrorFn2

--- a/errors.go
+++ b/errors.go
@@ -32,17 +32,15 @@ type Unwrappable interface {
 }
 
 // Wrap annotates an error, optionally with a formatted string.
-// if %w is used the argument will be unwrapped
 func Wrap(err error, format string, args ...any) error {
 	var note string
 
-	if err == nil {
+	switch {
+	case err == nil:
 		return nil
-	}
-
-	if len(args) > 0 {
-		note = fmt.Errorf(format, args...).Error()
-	} else {
+	case len(args) > 0:
+		note = fmt.Sprintf(format, args...)
+	default:
 		note = format
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -61,6 +61,13 @@ type WrappedError struct {
 }
 
 func (w *WrappedError) Error() string {
+	switch {
+	case w == nil:
+		return ""
+	case w.cause == nil:
+		return w.note
+	}
+
 	s := w.cause.Error()
 	if len(s) == 0 {
 		return w.note
@@ -70,6 +77,9 @@ func (w *WrappedError) Error() string {
 }
 
 func (w *WrappedError) Unwrap() error {
+	if w == nil {
+		return nil
+	}
 	return w.cause
 }
 

--- a/errors.go
+++ b/errors.go
@@ -33,6 +33,16 @@ type Unwrappable interface {
 
 // Wrap annotates an error, optionally with a formatted string.
 func Wrap(err error, format string, args ...any) error {
+	return doWrap(err, false, format, args...)
+}
+
+// QuietWrap replaces the text of the error it's wrapping.
+// if %w is used the argument will be unwrapped.
+func QuietWrap(err error, format string, args ...any) error {
+	return doWrap(err, true, format, args...)
+}
+
+func doWrap(err error, quiet bool, format string, args ...any) error {
 	var note string
 
 	switch {
@@ -51,6 +61,7 @@ func Wrap(err error, format string, args ...any) error {
 	return &WrappedError{
 		cause: err,
 		note:  note,
+		quiet: quiet,
 	}
 }
 
@@ -58,13 +69,14 @@ func Wrap(err error, format string, args ...any) error {
 type WrappedError struct {
 	cause error
 	note  string
+	quiet bool
 }
 
 func (w *WrappedError) Error() string {
 	switch {
 	case w == nil:
 		return ""
-	case w.cause == nil:
+	case w.cause == nil, w.quiet:
 		return w.note
 	}
 


### PR DESCRIPTION
### **User description**
to be used when you wrap something for error checks but you don't want its text version included in the text of the wrapper.

broken `%w` support dropped and `WrappedError` improved to survive a nil receiver

___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced a new `QuietWrap` function to wrap errors without expanding the cause.
- Refactored error wrapping logic into a new `doWrap` helper function.
- Enhanced the `WrappedError` struct to include a `quiet` field and updated its `Error` method to respect this flag.
- Updated the README documentation to include the new `QuietWrap` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.go</strong><dd><code>Introduce `QuietWrap` function and refactor error wrapping logic.</code></dd></summary>
<hr>
      
errors.go

<li>Introduced <code>QuietWrap</code> function to wrap errors without expanding the <br>cause.<br> <li> Added <code>doWrap</code> helper function to handle wrapping logic for both <code>Wrap</code> <br>and <code>QuietWrap</code>.<br> <li> Modified <code>WrappedError</code> struct to include a <code>quiet</code> field.<br> <li> Updated <code>Error</code> method of <code>WrappedError</code> to respect the <code>quiet</code> flag.<br>


</details>
    

  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/57/files#diff-76a7e0e299c7417bae32d3098e71370980157fe29e68a366671491d147d40572">+21/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation to include `QuietWrap` function.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

<li>Updated documentation to include <code>QuietWrap</code> in the list of error <br>handling functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/57/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

