### PR TITLE
introduce "As" helpers to help converting types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ should be on a subdirectory, it shouldn't be here.
 * Wrap/QuietWrap/Unwrappable/Unwrap
 * Errors/CompoundError
 * CoalesceError
+* AsError/AsErrors
 * IsError/IsErrorFn/IsErrorFn2
 * IsTemporary/CheckIsTemporary
 * IsTimeout/CheckIsTimeout

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ should be on a subdirectory, it shouldn't be here.
 
 * Zero/IsZero
 * Coalesce/IIf
+* As/AsFn
+* SliceAs/SliceAsFn
 * SliceContains/SliceContainsFn
 * SliceEqual/SliceEqualFn
 * SliceMinus/SliceMinusFn

--- a/as.go
+++ b/as.go
@@ -1,0 +1,42 @@
+package core
+
+// As returns a value cast to a different type
+func As[T, V any](v T) (V, bool) {
+	x, ok := any(v).(V)
+	return x, ok
+}
+
+// AsFn returns a value cast to a different type using a helper function
+func AsFn[T, V any](fn func(T) (V, bool), v T) (V, bool) {
+	if fn == nil {
+		var zero V
+		return zero, false
+	}
+
+	return fn(v)
+}
+
+// SliceAs returns a subset of a slice that could be cast into a different type
+func SliceAs[T, V any](vv []T) []V {
+	return SliceAsFn(As[T, V], vv)
+}
+
+// SliceAsFn returns a subset of a slice that could be cast into a different type,
+// using a helper function.
+func SliceAsFn[T, V any](fn func(T) (V, bool), vv []T) []V {
+	if fn == nil || len(vv) == 0 {
+		return nil
+	}
+
+	out := make([]V, 0, len(vv))
+	for _, v := range vv {
+		if x, ok := fn(v); ok {
+			out = append(out, x)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}


### PR DESCRIPTION
   * As() uses a standard type cast to convert a value to a different type.
   * AsFn() is like As() but uses a helper function.
   * SliceAs() uses a standard type cast and returns the subset of the values that could be converted to the requested type.
   *  SliceAsFn() is like SliceAs() but uses a helper function, and it is a simpler version of SliceMap()
   * AsError() uses known interfaces to decide if the argument is an error. If it's not an error, nil will be returned
   * AsErrors() uses AsError() to return a slice of actual errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and data manipulation capabilities introduced.
	- New functionalities: `As`, `AsFn`, `SliceAs`, `SliceAsFn`, `AsError`, and `AsErrors` added to improve type safety and error management.
- **Documentation**
	- Updated `README.md` to include new functionalities and their descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->