### PR TITLE
Add helpers from darvaza/shared/x

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ should be on a subdirectory, it shouldn't be here.
 * MapListCopy/MapListCopyFn
 * MapAllListContains/MapAllListContainsFn
 * MapAllListForEach/MapAllListForEachElement
+* MapValue
 * Keys()/SortedKeys()
 * NewContextKey
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ should be on a subdirectory, it shouldn't be here.
 * MapListInsert/MapListAppend
 * MapListInsertUnique/MapListInsertUniqueFn
 * MapListAppendUnique/MapListAppendUniqueFn
+* MapListCopy/MapListCopyFn
 * MapAllListContains/MapAllListContainsFn
 * MapAllListForEach/MapAllListForEachElement
 * Keys()/SortedKeys()

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ should be on a subdirectory, it shouldn't be here.
 * ListContains/ListContainsFn
 * ListForEach/ListForEachElement
 * ListForEachBackward/ListForEachBackwardElement
+* ListCopy/ListCopyFn
 * MapContains
 * MapListContains/MapListContainsFn
 * MapListForEach/MapListForEachElement

--- a/lists.go
+++ b/lists.go
@@ -96,3 +96,26 @@ func listIterBackwardStep(ref *list.Element) (e *list.Element, prev *list.Elemen
 	}
 	return ref, prev
 }
+
+// ListCopy makes a shallow copy of a list
+func ListCopy[T any](src *list.List) *list.List {
+	return ListCopyFn[T](src, nil)
+}
+
+// ListCopyFn makes a copy of a list using the given helper
+func ListCopyFn[T any](src *list.List, fn func(v T) (T, bool)) *list.List {
+	if fn == nil {
+		fn = func(v T) (T, bool) {
+			return v, true
+		}
+	}
+
+	out := list.New()
+	ListForEach(src, func(v0 T) bool {
+		if v1, ok := fn(v0); ok {
+			out.PushBack(v1)
+		}
+		return false
+	})
+	return out
+}

--- a/lists.go
+++ b/lists.go
@@ -104,6 +104,10 @@ func ListCopy[T any](src *list.List) *list.List {
 
 // ListCopyFn makes a copy of a list using the given helper
 func ListCopyFn[T any](src *list.List, fn func(v T) (T, bool)) *list.List {
+	if src == nil || src.Len() == 0 {
+		return list.New()
+	}
+
 	if fn == nil {
 		fn = func(v T) (T, bool) {
 			return v, true

--- a/maps.go
+++ b/maps.go
@@ -145,6 +145,23 @@ func MapListAppendUniqueFn[K comparable, T any](m map[K]*list.List, key K, v T,
 	}
 }
 
+// MapListCopy duplicates a map containing a list.List
+func MapListCopy[T comparable](src map[T]*list.List) map[T]*list.List {
+	fn := func(v any) (any, bool) { return v, true }
+	return MapListCopyFn(src, fn)
+}
+
+// MapListCopyFn duplicates a map containing a list.List but
+// allows the element's values to be cloned by a helper function
+func MapListCopyFn[K comparable, V any](src map[K]*list.List,
+	fn func(v V) (V, bool)) map[K]*list.List {
+	out := make(map[K]*list.List, len(src))
+	for k, l := range src {
+		out[k] = ListCopyFn(l, fn)
+	}
+	return out
+}
+
 // MapAllListContains check if a value exists on any entry of the map
 func MapAllListContains[K comparable, T comparable](m map[K]*list.List, v T) bool {
 	if m != nil {

--- a/maps.go
+++ b/maps.go
@@ -29,6 +29,15 @@ func SortedKeys[K Ordered, T any](m map[K]T) []K {
 	return keys
 }
 
+// MapValue returns a value of an entry or a default if
+// not found
+func MapValue[K comparable, V any](m map[K]V, key K, def V) (V, bool) {
+	if val, ok := m[key]; ok {
+		return val, true
+	}
+	return def, false
+}
+
 // MapContains tells if a given map contains a key.
 // this helper is intended for switch/case conditions
 func MapContains[K comparable](m map[K]any, key K) bool {


### PR DESCRIPTION
* ListCopy/ListCopyFn
* MapListCopy/MapListCopyFn
* MapValueOr

to drop `darvaza.org/darvaza/shared/x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added functions for copying lists (`ListCopy`, `ListCopyFn`) and maps (`MapListCopy`, `MapListCopyFn`), enhancing data manipulation capabilities.
	- Introduced `MapValue` for retrieving values from maps with a default return option.

- **Documentation**
	- Updated the README.md to include new exported functions, improving clarity on library capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->