### PR TITLE
errors: `Wrap()` for unformatted, `Wrapf()` for formatted [BREAKING]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ should be on a subdirectory, it shouldn't be here.
 The `Unwrappable` type represents the classic `Unwrap() error` interface implemented
 by `WrappedError`, while the `Errors` interface represents `Errors() []error`.
 
-There are two factories for `Unwrappable`, the standard `"note: error description"` and a
-quiet one, not including the text of the original error unless unwrapped first.
+There are three factories for `Unwrappable`, the standard `"note: error description"`,
+one for formatted notes, and a quiet one, not including the text of the original error
+unless unwrapped first.
 
-* `Wrap(err, note)` with a simple string, or with a formatted note `Wrap(err, format, args...)`.
-* And the same for `QuietWrap(err, note)` or `QuietWrap(err, format, args...)`.
+* `Wrap(err, note)` with a simple string,
+* `Wrapf(err, format, args...)` when using a formatted note,
+* and `QuietWrapf(err, format, args...)` for formatted errors not including
+  the wrapped message in the text.
 
 The `Unwrap(err error) []error` helper returns a slice of non-nil sub-errors built
 from the following interfaces:

--- a/compounderror.go
+++ b/compounderror.go
@@ -102,7 +102,7 @@ func (w *CompoundError) Append(err error, note string, args ...any) {
 		err = errors.New(note)
 	case note != "":
 		// wrap
-		err = Wrap(err, "%s", note)
+		err = Wrap(err, note)
 	}
 
 	w.Errs = append(w.Errs, err)

--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,7 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 	// ErrTODO is like ErrNotImplemented but used especially to
 	// indicate something needs to be implemented
-	ErrTODO = Wrap(ErrNotImplemented, "%s", "TODO")
+	ErrTODO = Wrap(ErrNotImplemented, "TODO")
 	// ErrExists indicates something already exists
 	ErrExists = errors.New("already exists")
 	// ErrNotExists indicates something doesn't exist
@@ -31,13 +31,17 @@ type Unwrappable interface {
 	Unwrap() error
 }
 
-// Wrap annotates an error, optionally with a formatted string.
-func Wrap(err error, format string, args ...any) error {
+// Wrap annotates an error with a single string.
+func Wrap(err error, msg string) error {
+	return doWrap(err, false, "%s", msg)
+}
+
+// Wrapf annotates an error with a formatted string.
+func Wrapf(err error, format string, args ...any) error {
 	return doWrap(err, false, format, args...)
 }
 
 // QuietWrap replaces the text of the error it's wrapping.
-// if %w is used the argument will be unwrapped.
 func QuietWrap(err error, format string, args ...any) error {
 	return doWrap(err, true, format, args...)
 }

--- a/panicerror.go
+++ b/panicerror.go
@@ -69,8 +69,17 @@ func NewPanicErrorf(skip int, format string, args ...any) *PanicError {
 }
 
 // NewPanicWrap creates a new PanicError wrapping a given error
-// annotated, optionally formatted. %w is expanded.
-func NewPanicWrap(skip int, err error, format string, args ...any) *PanicError {
+// annotated with a single string.
+func NewPanicWrap(skip int, err error, note string) *PanicError {
+	return &PanicError{
+		payload: Wrap(err, note),
+		stack:   StackTrace(skip + 1),
+	}
+}
+
+// NewPanicWrapf creates a new PanicError wrapping a given error
+// annotated with a formatted string.
+func NewPanicWrapf(skip int, err error, format string, args ...any) *PanicError {
 	return &PanicError{
 		payload: Wrapf(err, format, args...),
 		stack:   StackTrace(skip + 1),
@@ -87,8 +96,13 @@ func Panicf(format string, args ...any) {
 	panic(NewPanicErrorf(1, format, args...))
 }
 
-// PanicWrap emits a PanicError wrapping an annotated error, optionally
-// formatted. %w is expanded.
-func PanicWrap(err error, format string, args ...any) {
-	panic(NewPanicWrap(1, err, format, args...))
+// PanicWrap emits a PanicError wrapping an annotated error.
+func PanicWrap(err error, note string) {
+	panic(NewPanicWrap(1, err, note))
+}
+
+// PanicWrapf emits a PanicError wrapping an annotated error using
+// a formatting string.
+func PanicWrapf(err error, format string, args ...any) {
+	panic(NewPanicWrapf(1, err, format, args...))
 }

--- a/panicerror.go
+++ b/panicerror.go
@@ -72,7 +72,7 @@ func NewPanicErrorf(skip int, format string, args ...any) *PanicError {
 // annotated, optionally formatted. %w is expanded.
 func NewPanicWrap(skip int, err error, format string, args ...any) *PanicError {
 	return &PanicError{
-		payload: Wrap(err, format, args...),
+		payload: Wrapf(err, format, args...),
 		stack:   StackTrace(skip + 1),
 	}
 }

--- a/sync.go
+++ b/sync.go
@@ -281,7 +281,7 @@ func (eg *ErrGroup) GoCatch(run func(context.Context) error,
 	var c2 func(error) error
 
 	if run == nil {
-		PanicWrap(ErrInvalid, "%s", "run function not specified")
+		PanicWrap(ErrInvalid, "run function not specified")
 	}
 
 	eg.init()


### PR DESCRIPTION
and choose `golangci-lint` and `revive` version based on the Go version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error wrapping function `Wrapf` for enhanced flexibility in error annotations.
	- Added a script for dynamic version retrieval of Go tools.

- **Improvements**
	- Expanded testing coverage by including an additional Go version in the workflow.
	- Updated tool versions in the build process for better compatibility.
	- Simplified error handling processes in various functions, enhancing clarity and usability.

- **Documentation**
	- Restructured the "Errors" section in the README to provide clearer guidance on error handling mechanisms.
	- Added a new subsection on "Wrappers" detailing error wrapping functions and their usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->