### PR TITLE
build-sys: peek golangci-lint and revive version based on the Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ TOOLSDIR := $(CURDIR)/internal/build
 TMPDIR ?= $(CURDIR)/.tmp
 OUTDIR ?= $(TMPDIR)
 
-GOLANGCI_LINT_VERSION ?= v1.55
-REVIVE_VERSION ?= v1.3.7
+# Dynamic version selection based on Go version
+# Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.3 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/internal/build/get_version.sh
+++ b/internal/build/get_version.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -eu
+
+xy_ver() {
+	local ver="${1:-}"
+	local x y
+
+	if echo "v${ver}" | grep -qe '^v[0-9]\+\.[0-9]\+\(\..*\|$\)'; then
+		x="$(echo "$ver" | cut -d. -f1)"
+		y="$(echo "$ver" | cut -d. -f2)"
+		echo $((x * 1000 + y))
+	else
+		echo "invalid version format: $ver" >&2
+		return 1
+	fi
+}
+
+GO_VERSION=$(${GO:-go} version | sed -ne 's|.* go\([0-9][^ ]\+\)[ $].*|\1|p')
+
+if [ $# -eq 0 ]; then
+	# no arguments, go version
+	echo "$GO_VERSION"
+	exit 0
+fi
+
+if [ $# -gt 1 ]; then
+	# base go version and at least one target
+	GO_VER=$(xy_ver "$GO_VERSION")
+	[ -n "$GO_VER" ] || exit 1
+
+	BASE_VER=$(xy_ver "$1")
+	[ -n "$BASE_VER" ] || exit 1
+
+	shift
+	if [ "$GO_VER" -ge "$BASE_VER" ]; then
+		VER="$BASE_VER"
+
+		for value; do
+			[ "$GO_VER" -gt "$VER" ] || break
+
+			: $(( VER = VER + 1 ))
+		done
+
+		# match or last
+		echo "$value"
+		exit 0
+	fi
+fi
+
+echo "unknown"
+exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new script to dynamically retrieve and compare Go language versions for improved version management.
	- Updated versioning for linting tools to automatically fetch the latest compatible versions.

- **Bug Fixes**
	- Enhanced version retrieval process to ensure accurate versioning of tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->