### PR TITLE
test under Go 1.23 using golangci-lint v1.61

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.20', '1.21', '1.22' ]
+        go: [ '1.20', '1.21', '1.22', '1.23' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59 v1.59 v1.60)
 REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.3 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59 v1.59 v1.60)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59 v1.61)
 REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.3 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/compounderror.go
+++ b/compounderror.go
@@ -102,7 +102,7 @@ func (w *CompoundError) Append(err error, note string, args ...any) {
 		err = errors.New(note)
 	case note != "":
 		// wrap
-		err = Wrap(err, note)
+		err = Wrap(err, "%s", note)
 	}
 
 	w.Errs = append(w.Errs, err)

--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,7 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 	// ErrTODO is like ErrNotImplemented but used especially to
 	// indicate something needs to be implemented
-	ErrTODO = Wrap(ErrNotImplemented, "TODO")
+	ErrTODO = Wrap(ErrNotImplemented, "%s", "TODO")
 	// ErrExists indicates something already exists
 	ErrExists = errors.New("already exists")
 	// ErrNotExists indicates something doesn't exist

--- a/sync.go
+++ b/sync.go
@@ -281,7 +281,7 @@ func (eg *ErrGroup) GoCatch(run func(context.Context) error,
 	var c2 func(error) error
 
 	if run == nil {
-		PanicWrap(ErrInvalid, "run function not specified")
+		PanicWrap(ErrInvalid, "%s", "run function not specified")
 	}
 
 	eg.init()


### PR DESCRIPTION
golangci-lint v1.59 crashes under go1.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and reporting in the `ErrGroup` functionality.
	- Introduced a method for standardized error handling during worker execution.

- **Improvements**
	- Updated error formatting for better clarity and context inclusion.
	- Expanded the build matrix to include Go version 1.23 for better compatibility.
	- Updated the GolangCI Lint version selection for broader version support.

- **Bug Fixes**
	- Improved the wrapping of error messages for dynamic content insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->