### PR TITLE
build-sys: remove `-o` from column, remove `-tags tools` exception, and introduce GOUP_PACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ GO ?= go
 GOFMT ?= gofmt
 GOFMT_FLAGS = -w -l -s
 GOGENERATE_FLAGS = -v
+GOUP_FLAGS ?= -v
+GOUP_PACKAGES ?= ./...
 
 TOOLSDIR := $(CURDIR)/internal/build
 TMPDIR ?= $(CURDIR)/.tmp

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -129,7 +129,7 @@ gen_make_targets() {
 		depsx="fmt"
 		;;
 	up)
-		call="\$(GO) get -u -v ./...
+		call="\$(GO) get -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)
 \$(GO) mod tidy"
 		;;
 	test)
@@ -159,17 +159,15 @@ gen_make_targets() {
 			# special case
 			case "$cmd" in
 			get)
-				cmdx="get -tags tools"
+				cmdx="get -tags tools -v ./..."
 				;;
 			up)
-				cmdx="get -tags tools -u"
+				cmdx="get -tags tools -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)"
 				;;
 			*)
 				cmdx=
 				;;
 			esac
-
-			[ -z "$cmdx" ] || cmdx="\$(GO) $cmdx -v ./..."
 
 			case "$cmd" in
 			up)

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -102,7 +102,7 @@ EOT
 		cat <<-EOT
 		$files$TAB=$TAB$files_cmd
 		EOT
-	done < "$INDEX" | column -t -s "$TAB" -o " "
+	done < "$INDEX" | column -t -s "$TAB"
 }
 
 gen_make_targets() {

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -187,7 +187,7 @@ gen_make_targets() {
 		files=GO_FILES_$(gen_var_name "$name")
 		cat <<EOT
 
-$cmd-$name:${deps:+ $(prefixed $cmd $deps)}${depsx:+ | $depsx} ; \$(info \$(M) $cmd: $name)
+$cmd-$name:${deps:+ $(prefixed "$cmd" $deps)}${depsx:+ | $depsx} ; \$(info \$(M) $cmd: $name)
 EOT
 	if [ -n "$callu" ]; then
 		# unconditionally
@@ -204,7 +204,7 @@ EOT
 gen_files_lists
 
 for cmd in $COMMANDS; do
-	all="$(prefixed $cmd $PROJECTS)"
+	all="$(prefixed "$cmd" $PROJECTS)"
 	depsx=
 
 	cat <<EOT
@@ -223,6 +223,6 @@ done
 for x in $PROJECTS; do
 	cat <<EOT
 
-$x: $(suffixed $x get build tidy)
+$x: $(suffixed "$x" get build tidy)
 EOT
 done

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -78,7 +78,6 @@ gen_files_lists() {
 	cat <<EOT
 GO_FILES = \$(shell find * \\
 	-type d -name node_modules -prune -o \\
-	-path internal/build -prune -o \\
 	-type f -name '*.go' -print )
 
 EOT
@@ -108,7 +107,7 @@ EOT
 gen_make_targets() {
 	local cmd="$1" name="$2" dir="$3" mod="$4" deps="$5"
 	local call= callu= callx=
-	local depsx= cmdx=
+	local depsx=
 	local sequential=
 
 	# default calls
@@ -155,35 +154,7 @@ gen_make_targets() {
 			cd="cd '$dir'; "
 		fi
 
-		if [ "$name" = root ]; then
-			# special case
-			case "$cmd" in
-			get)
-				cmdx="get -tags tools -v ./..."
-				;;
-			up)
-				cmdx="get -tags tools -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)"
-				;;
-			*)
-				cmdx=
-				;;
-			esac
-
-			case "$cmd" in
-			up)
-				callx="$cmdx
-\$(GO) mod tidy"
-				;;
-			get)
-				callx="$cmdx"
-				;;
-			*)
-				callx="$call"
-				;;
-			esac
-		else
-			callx="$call"
-		fi
+		callx="$call"
 
 		if [ "build" = "$cmd" ]; then
 			# special build flags for cmd/*

--- a/internal/build/tools.go
+++ b/internal/build/tools.go
@@ -1,3 +1,0 @@
-//go:build tools
-
-package build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new variables `GOUP_FLAGS` and `GOUP_PACKAGES` for enhanced Go module management.

- **Improvements**
	- Enhanced whitespace handling and file list generation in the Makefile generation script.
	- Streamlined command generation logic for better readability and maintainability.

- **Bug Fixes**
	- Improved output formatting for Makefile targets and commands.

- **Chores**
	- Removed the `internal/build/tools.go` file to simplify tool dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->