### PR TITLE
build-sys: drop go1.20 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.20', '1.21', '1.22', '1.23' ]
+        go: [ '1.21', '1.22', '1.23' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.55 v1.59 v1.61)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.20 v1.3 v1.4)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.59 v1.61)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/core
 
-go 1.20
+go 1.21
 
 require golang.org/x/net v0.29.0
 


### PR DESCRIPTION
to limit it to three Go minors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated supported Go versions to 1.21, 1.22, and 1.23 for enhanced compatibility.
  
- **Bug Fixes**
	- Adjusted tool versions for linting and code analysis, potentially improving code quality and performance.

- **Documentation**
	- Updated Go version in project documentation to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->