### PR TITLE
build-sys: fix `make tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module darvaza.org/core
 
 go 1.21
 
-require golang.org/x/net v0.29.0
+require golang.org/x/net v0.30.0
 
-require golang.org/x/text v0.18.0 // indirect
+require golang.org/x/text v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
-golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
-golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
-golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -106,7 +106,7 @@ EOT
 
 gen_make_targets() {
 	local cmd="$1" name="$2" dir="$3" mod="$4" deps="$5"
-	local call= callu= callx=
+	local call= callu=
 	local depsx=
 	local sequential=
 
@@ -158,7 +158,7 @@ gen_make_targets() {
 	build)
 		# special build flags for cmd/*
 		#
-		callx="$(cat <<-EOL | packed_oneline
+		call="$(cat <<-EOL | packed_oneline
 		set -e
 		MOD="\$\$(\$(GO) list -f '{{.ImportPath}}' ./...)"
 		if echo "\$\$MOD" | grep -q -e '.*/cmd/[^/]\+\$\$'; then
@@ -174,11 +174,8 @@ gen_make_targets() {
 		#
 		exclude=$(gen_revive_exclude "$dir")
 		if [ -n "$exclude" ]; then
-			callx=$(echo "$call" | sed -e "s;\(REVIVE)\);\1 $exclude;")
+			call=$(echo "$call" | sed -e "s;\(REVIVE)\);\1 $exclude;")
 		fi
-		;;
-	*)
-		callx="$call"
 		;;
 	esac
 
@@ -196,10 +193,10 @@ EOT
 		# unconditionally
 		echo "$callu" | sed -e "/^$/d;" -e "s|^|\t\$(Q) $cd|"
 	fi
-	if [ -n "$callx" ]; then
+	if [ -n "$call" ]; then
 		# only if there are files
 		echo "ifneq (\$($files),)"
-		echo "$callx" | sed -e "/^$/d;" -e "s|^|\t\$(Q) $cd|"
+		echo "$call" | sed -e "/^$/d;" -e "s|^|\t\$(Q) $cd|"
 		echo "endif"
 	fi
 }


### PR DESCRIPTION
`callx` was empty for `tidy` when there were no exclusions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated module versions for `golang.org/x/net` and `golang.org/x/text` to enhance dependency management.
	- Simplified the command execution logic in the `gen_mk.sh` script for improved clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->