### PR TITLE
stack: fix generics support when splitting package name

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -77,7 +77,9 @@ func (f Frame) PkgName() string {
 
 // SplitName returns package name and function name
 func (f Frame) SplitName() (pkgName string, funcName string) {
-	i := strings.LastIndexAny(f.name, "./")
+	// ignore trailing[...] from generic functions
+	name, _ := strings.CutSuffix(f.name, "[...]")
+	i := strings.LastIndexAny(name, "./")
 	if i < 0 {
 		return "", f.name
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the `SplitName` method to remove trailing "[...]" suffix from function names, enhancing clarity and accuracy in function identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->