### PR TITLE
maps: introduce SortedValues() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ should be on a subdirectory, it shouldn't be here.
 * ListForEach/ListForEachElement
 * ListForEachBackward/ListForEachBackwardElement
 * ListCopy/ListCopyFn
-* MapContains
 * MapListContains/MapListContainsFn
 * MapListForEach/MapListForEachElement
 * MapListInsert/MapListAppend
@@ -56,8 +55,16 @@ should be on a subdirectory, it shouldn't be here.
 * MapListCopy/MapListCopyFn
 * MapAllListContains/MapAllListContainsFn
 * MapAllListForEach/MapAllListForEachElement
-* MapValue
-* Keys()/SortedKeys()
+
+### Maps
+
+* `MapContains()` checks if a map contains a key. Useful for switch/case tests.
+* `MapValue()` returns the value for a key, or a given fallback value if the key is not present.
+* `Keys()` returns a slice of the keys in the map.
+* `SortedKeys()` returns a sorted slice of the keys in the map.
+* `SortedValues()` returns a slice of the values in the map, sorted by key.
+* `SortedValuesCond()` returns a slice of the values in the map, sorted by key, and optionally filtered by a condition function.
+* `SortedValuesUnlikelyCond()` is like `SortedValuesCond()` but it doesn't reallocate the slice.
 
 ## Errors
 

--- a/maps.go
+++ b/maps.go
@@ -29,6 +29,48 @@ func SortedKeys[K Ordered, T any](m map[K]T) []K {
 	return keys
 }
 
+// SortedValues returns a slice of values from the map, sorted by their keys
+func SortedValues[K Ordered, T any](m map[K]T) []T {
+	var out []T
+	if l := len(m); l > 0 {
+		out = make([]T, 0, l)
+		out = doSortedValues(out, m, nil)
+	}
+	return out
+}
+
+// SortedValuesCond returns a slice of values from the map, sorted by their keys,
+// filtered by the optional predicate function fn, preallocated to the size of the map.
+func SortedValuesCond[K Ordered, T any](m map[K]T, fn func(T) bool) []T {
+	var out []T
+	if l := len(m); l > 0 {
+		out = make([]T, 0, l)
+		out = doSortedValues(out, m, fn)
+	}
+	return out
+}
+
+// SortedValuesUnlikelyCond returns a slice of values from the map, sorted by their keys,
+// filtered by the optional predicate function fn, without preallocation.
+func SortedValuesUnlikelyCond[K Ordered, T any](m map[K]T, fn func(T) bool) []T {
+	var out []T
+	if len(m) > 0 {
+		out = doSortedValues(nil, m, fn)
+	}
+	return out
+}
+
+func doSortedValues[K Ordered, T any](out []T, m map[K]T, fn func(T) bool) []T {
+	for _, k := range SortedKeys(m) {
+		if v, ok := m[k]; ok {
+			if fn == nil || fn(v) {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
 // MapValue returns a value of an entry or a default if
 // not found
 func MapValue[K comparable, V any](m map[K]V, key K, def V) (V, bool) {


### PR DESCRIPTION
also providing conditional variants, with and without preallocation.
* SortedValues() - unconditional
* SortedValuesCond() - conditional with preallocation
* SortedValuesUnlikelyCond() - conditional without preallocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined the map functionalities documentation with a new section offering clearer descriptions of map operations.
- **New Features**
  - Introduced enhanced utilities for retrieving ordered map values with added flexibility for filtering and sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->