### PR TITLE
test(errors): add comprehensive tests for error handling utilities

### DIFF
--- a/compounderror_test.go
+++ b/compounderror_test.go
@@ -1,0 +1,486 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type compoundErrorErrorTestCase struct {
+	name     string
+	errs     []error
+	expected string
+}
+
+var compoundErrorErrorTestCases = []compoundErrorErrorTestCase{
+	{
+		name:     "empty errors",
+		errs:     []error{},
+		expected: "",
+	},
+	{
+		name:     "single error",
+		errs:     []error{errors.New("first error")},
+		expected: "first error",
+	},
+	{
+		name:     "multiple errors",
+		errs:     []error{errors.New("first error"), errors.New("second error")},
+		expected: "first error\nsecond error",
+	},
+	{
+		name:     "with nil errors",
+		errs:     []error{errors.New("first error"), nil, errors.New("third error")},
+		expected: "first error\nthird error",
+	},
+	{
+		name:     "all nil errors",
+		errs:     []error{nil, nil, nil},
+		expected: "",
+	},
+}
+
+func (tc compoundErrorErrorTestCase) test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.errs}
+	result := ce.Error()
+
+	if result != tc.expected {
+		t.Fatalf("expected '%s', got '%s'", tc.expected, result)
+	}
+}
+
+func TestCompoundErrorError(t *testing.T) {
+	for _, tc := range compoundErrorErrorTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestCompoundErrorErrors(t *testing.T) {
+	errs := []error{
+		errors.New("first error"),
+		errors.New("second error"),
+	}
+
+	ce := &CompoundError{Errs: errs}
+	result := ce.Errors()
+
+	if len(result) != len(errs) {
+		t.Fatalf("expected %d errors, got %d", len(errs), len(result))
+	}
+
+	for i, err := range result {
+		if err != errs[i] {
+			t.Fatalf("expected error %d to be %v, got %v", i, errs[i], err)
+		}
+	}
+}
+
+func TestCompoundErrorUnwrap(t *testing.T) {
+	errs := []error{
+		errors.New("first error"),
+		errors.New("second error"),
+	}
+
+	ce := &CompoundError{Errs: errs}
+	result := ce.Unwrap()
+
+	if len(result) != len(errs) {
+		t.Fatalf("expected %d errors, got %d", len(errs), len(result))
+	}
+
+	for i, err := range result {
+		if err != errs[i] {
+			t.Fatalf("expected error %d to be %v, got %v", i, errs[i], err)
+		}
+	}
+}
+
+type compoundErrorOkTestCase struct {
+	name     string
+	errs     []error
+	expected bool
+}
+
+var compoundErrorOkTestCases = []compoundErrorOkTestCase{
+	{
+		name:     "empty errors",
+		errs:     []error{},
+		expected: true,
+	},
+	{
+		name:     "nil slice",
+		errs:     nil,
+		expected: true,
+	},
+	{
+		name:     "single error",
+		errs:     []error{errors.New("error")},
+		expected: false,
+	},
+	{
+		name:     "multiple errors",
+		errs:     []error{errors.New("first"), errors.New("second")},
+		expected: false,
+	},
+}
+
+func (tc compoundErrorOkTestCase) test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.errs}
+	result := ce.Ok()
+
+	if result != tc.expected {
+		t.Fatalf("expected %t, got %t", tc.expected, result)
+	}
+}
+
+func TestCompoundErrorOk(t *testing.T) {
+	for _, tc := range compoundErrorOkTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+type compoundErrorAsErrorTestCase struct {
+	name      string
+	errs      []error
+	expectNil bool
+}
+
+var compoundErrorAsErrorTestCases = []compoundErrorAsErrorTestCase{
+	{
+		name:      "empty errors",
+		errs:      []error{},
+		expectNil: true,
+	},
+	{
+		name:      "nil slice",
+		errs:      nil,
+		expectNil: true,
+	},
+	{
+		name:      "single error",
+		errs:      []error{errors.New("error")},
+		expectNil: false,
+	},
+	{
+		name:      "multiple errors",
+		errs:      []error{errors.New("first"), errors.New("second")},
+		expectNil: false,
+	},
+}
+
+func (tc compoundErrorAsErrorTestCase) test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.errs}
+	result := ce.AsError()
+
+	if tc.expectNil {
+		if result != nil {
+			t.Fatalf("expected nil, got %v", result)
+		}
+	} else {
+		if result == nil {
+			t.Fatalf("expected non-nil error, got nil")
+		}
+		if result != ce {
+			t.Fatalf("expected same CompoundError instance, got different")
+		}
+	}
+}
+
+func TestCompoundErrorAsError(t *testing.T) {
+	for _, tc := range compoundErrorAsErrorTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+type compoundErrorAppendErrorTestCase struct {
+	name        string
+	initial     []error
+	toAppend    []error
+	expectedLen int
+}
+
+var compoundErrorAppendErrorTestCases = []compoundErrorAppendErrorTestCase{
+	{
+		name:        "append to empty",
+		initial:     []error{},
+		toAppend:    []error{errors.New("first")},
+		expectedLen: 1,
+	},
+	{
+		name:        "append multiple",
+		initial:     []error{errors.New("existing")},
+		toAppend:    []error{errors.New("first"), errors.New("second")},
+		expectedLen: 3,
+	},
+	{
+		name:        "append with nils",
+		initial:     []error{errors.New("existing")},
+		toAppend:    []error{nil, errors.New("valid"), nil},
+		expectedLen: 2,
+	},
+	{
+		name:        "append all nils",
+		initial:     []error{errors.New("existing")},
+		toAppend:    []error{nil, nil},
+		expectedLen: 1,
+	},
+}
+
+func (tc compoundErrorAppendErrorTestCase) test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.initial}
+	result := ce.AppendError(tc.toAppend...)
+
+	// Test method chaining
+	if result != ce {
+		t.Fatalf("expected same CompoundError instance for chaining")
+	}
+
+	// Test length
+	if len(ce.Errs) != tc.expectedLen {
+		t.Fatalf("expected %d errors, got %d", tc.expectedLen, len(ce.Errs))
+	}
+
+	// Test no nil errors were added
+	for i, err := range ce.Errs {
+		if err == nil {
+			t.Fatalf("unexpected nil error at index %d", i)
+		}
+	}
+}
+
+func TestCompoundErrorAppendError(t *testing.T) {
+	for _, tc := range compoundErrorAppendErrorTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestCompoundErrorAppendErrorWithCompoundError(t *testing.T) {
+	ce1 := &CompoundError{Errs: []error{errors.New("first")}}
+	ce2 := &CompoundError{Errs: []error{errors.New("second"), errors.New("third")}}
+
+	result := ce1.AppendError(ce2)
+
+	// Test method chaining
+	if result != ce1 {
+		t.Fatalf("expected same CompoundError instance for chaining")
+	}
+
+	// Should unwrap the compound error and append individual errors
+	expectedLen := 3 // original 1 + unwrapped 2
+	if len(ce1.Errs) != expectedLen {
+		t.Fatalf("expected %d errors, got %d", expectedLen, len(ce1.Errs))
+	}
+
+	// Check error messages
+	errorStr := ce1.Error()
+	if !strings.Contains(errorStr, "first") {
+		t.Fatalf("expected 'first' in error string, got '%s'", errorStr)
+	}
+	if !strings.Contains(errorStr, "second") {
+		t.Fatalf("expected 'second' in error string, got '%s'", errorStr)
+	}
+	if !strings.Contains(errorStr, "third") {
+		t.Fatalf("expected 'third' in error string, got '%s'", errorStr)
+	}
+}
+
+type mockUnwrappable struct {
+	errs []error
+}
+
+func (*mockUnwrappable) Error() string {
+	return "mock unwrappable error"
+}
+
+func (m *mockUnwrappable) Unwrap() []error {
+	return m.errs
+}
+
+func TestCompoundErrorAppendErrorWithUnwrappable(t *testing.T) {
+	ce := &CompoundError{Errs: []error{errors.New("initial")}}
+	mock := &mockUnwrappable{
+		errs: []error{errors.New("unwrapped1"), errors.New("unwrapped2")},
+	}
+
+	result := ce.AppendError(mock)
+
+	// Test method chaining
+	if result != ce {
+		t.Fatalf("expected same CompoundError instance for chaining")
+	}
+
+	// Should unwrap and append individual errors
+	expectedLen := 3 // original 1 + unwrapped 2
+	if len(ce.Errs) != expectedLen {
+		t.Fatalf("expected %d errors, got %d", expectedLen, len(ce.Errs))
+	}
+}
+
+type compoundErrorAppendTestCase struct {
+	name        string
+	initial     []error
+	err         error
+	note        string
+	args        []any
+	expectedLen int
+	expectNote  bool
+}
+
+var compoundErrorAppendTestCases = []compoundErrorAppendTestCase{
+	{
+		name:        "nil error, empty note",
+		initial:     []error{},
+		err:         nil,
+		note:        "",
+		args:        nil,
+		expectedLen: 0,
+		expectNote:  false,
+	},
+	{
+		name:        "nil error, with note",
+		initial:     []error{},
+		err:         nil,
+		note:        "note only",
+		args:        nil,
+		expectedLen: 1,
+		expectNote:  true,
+	},
+	{
+		name:        "error without note",
+		initial:     []error{},
+		err:         errors.New("test error"),
+		note:        "",
+		args:        nil,
+		expectedLen: 1,
+		expectNote:  false,
+	},
+	{
+		name:        "error with note",
+		initial:     []error{},
+		err:         errors.New("test error"),
+		note:        "wrapped note",
+		args:        nil,
+		expectedLen: 1,
+		expectNote:  true,
+	},
+	{
+		name:        "formatted note",
+		initial:     []error{},
+		err:         errors.New("test error"),
+		note:        "wrapped %s: %d",
+		args:        []any{"note", 42},
+		expectedLen: 1,
+		expectNote:  true,
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc compoundErrorAppendTestCase) test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.initial}
+	result := ce.Append(tc.err, tc.note, tc.args...)
+
+	// Test method chaining
+	if result != ce {
+		t.Fatalf("expected same CompoundError instance for chaining")
+	}
+
+	// Test length
+	if len(ce.Errs) != tc.expectedLen {
+		t.Fatalf("expected %d errors, got %d", tc.expectedLen, len(ce.Errs))
+	}
+
+	if tc.expectedLen > 0 {
+		lastErr := ce.Errs[len(ce.Errs)-1]
+		if lastErr == nil {
+			t.Fatalf("expected non-nil error")
+		}
+
+		errorStr := lastErr.Error()
+		if tc.expectNote {
+			if tc.note != "" {
+				expectedNote := tc.note
+				if len(tc.args) > 0 {
+					expectedNote = "wrapped note: 42" // for the formatted case
+				}
+				if !strings.Contains(errorStr, expectedNote) && !strings.Contains(errorStr, tc.note) {
+					t.Fatalf("expected note in error string, got '%s'", errorStr)
+				}
+			}
+		}
+	}
+}
+
+func TestCompoundErrorAppend(t *testing.T) {
+	for _, tc := range compoundErrorAppendTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestCompoundErrorAppendChaining(t *testing.T) {
+	ce := &CompoundError{}
+
+	result := ce.
+		Append(errors.New("first"), "").
+		Append(nil, "second note").
+		AppendError(errors.New("third")).
+		Append(errors.New("fourth"), "wrapped %s", "note")
+
+	// Test method chaining returns same instance
+	if result != ce {
+		t.Fatalf("expected same CompoundError instance for chaining")
+	}
+
+	// Test final length
+	expectedLen := 4
+	if len(ce.Errs) != expectedLen {
+		t.Fatalf("expected %d errors, got %d", expectedLen, len(ce.Errs))
+	}
+
+	// Test that all errors are non-nil
+	for i, err := range ce.Errs {
+		if err == nil {
+			t.Fatalf("unexpected nil error at index %d", i)
+		}
+	}
+}
+
+func TestCompoundErrorNilHandling(t *testing.T) {
+	// Test that nil errors are properly filtered out
+	ce := &CompoundError{}
+
+	_ = ce.AppendError(nil, errors.New("valid"), nil)
+
+	if len(ce.Errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(ce.Errs))
+	}
+
+	if ce.Errs[0].Error() != "valid" {
+		t.Fatalf("expected 'valid' error, got '%s'", ce.Errs[0].Error())
+	}
+}
+
+func TestCompoundErrorIsInterface(t *testing.T) {
+	ce := &CompoundError{Errs: []error{errors.New("test")}}
+
+	// Test Errors interface
+	var _ Errors = ce
+
+	// Test that it implements error interface
+	var _ error = ce
+
+	// Test that Error() method works
+	if ce.Error() == "" {
+		t.Fatalf("expected non-empty error string")
+	}
+
+	// Test that Errors() method works
+	errs := ce.Errors()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+}

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,442 @@
+package core
+
+import (
+	"errors"
+	"testing"
+)
+
+type asRecoveredTestCase struct {
+	name     string
+	input    any
+	expected any
+	isNil    bool
+}
+
+var asRecoveredTestCases = []asRecoveredTestCase{
+	{
+		name:     "nil input",
+		input:    nil,
+		expected: nil,
+		isNil:    true,
+	},
+	{
+		name:     "string panic",
+		input:    "test panic",
+		expected: "test panic",
+		isNil:    false,
+	},
+	{
+		name:     "error panic",
+		input:    errors.New("test error"),
+		expected: "test error", // String comparison for error content
+		isNil:    false,
+	},
+	{
+		name:     "int panic",
+		input:    42,
+		expected: 42,
+		isNil:    false,
+	},
+	{
+		name:     "already recovered",
+		input:    NewPanicError(1, "already wrapped"),
+		expected: "already wrapped",
+		isNil:    false,
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+//revive:disable-next-line:cyclomatic
+func (tc asRecoveredTestCase) test(t *testing.T) {
+	t.Helper()
+	result := AsRecovered(tc.input)
+
+	if tc.isNil {
+		if result != nil {
+			t.Fatalf("expected nil, got %v", result)
+		}
+		return
+	}
+
+	if result == nil {
+		t.Fatalf("expected non-nil result, got nil")
+	}
+
+	// Test Recovered interface
+	recovered := result.Recovered()
+
+	// Handle different types appropriately for comparison
+	switch exp := tc.expected.(type) {
+	case string:
+		// For string inputs, they get converted to errors
+		if err, ok := recovered.(error); ok {
+			if err.Error() != exp {
+				t.Fatalf("expected recovered error '%s', got '%s'", exp, err.Error())
+			}
+		} else if recovered != exp {
+			t.Fatalf("expected recovered value %v, got %v", exp, recovered)
+		}
+	case error:
+		if err, ok := recovered.(error); ok {
+			if err.Error() != exp.Error() {
+				t.Fatalf("expected recovered error '%s', got '%s'", exp.Error(), err.Error())
+			}
+		} else {
+			t.Fatalf("expected error type, got %T", recovered)
+		}
+	default:
+		if recovered != tc.expected {
+			t.Fatalf("expected recovered value %v, got %v", tc.expected, recovered)
+		}
+	}
+
+	// Test Error method
+	errorStr := result.Error()
+	if errorStr == "" {
+		t.Fatalf("expected non-empty error string")
+	}
+}
+
+func TestAsRecovered(t *testing.T) {
+	for _, tc := range asRecoveredTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+type catcherDoTestCase struct {
+	name        string
+	fn          func() error
+	expectError bool
+	expectPanic bool
+}
+
+var catcherDoTestCases = []catcherDoTestCase{
+	{
+		name: "successful function",
+		fn: func() error {
+			return nil
+		},
+		expectError: false,
+		expectPanic: false,
+	},
+	{
+		name: "function returns error",
+		fn: func() error {
+			return errors.New("test error")
+		},
+		expectError: true,
+		expectPanic: false,
+	},
+	{
+		name: "function panics with string",
+		fn: func() error {
+			panic("test panic")
+		},
+		expectError: true,
+		expectPanic: true,
+	},
+	{
+		name: "function panics with error",
+		fn: func() error {
+			panic(errors.New("panic error"))
+		},
+		expectError: true,
+		expectPanic: true,
+	},
+	{
+		name: "function panics with int",
+		fn: func() error {
+			panic(42)
+		},
+		expectError: true,
+		expectPanic: true,
+	},
+	{
+		name:        "nil function",
+		fn:          nil,
+		expectError: false,
+		expectPanic: false,
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc catcherDoTestCase) test(t *testing.T) {
+	t.Helper()
+	var catcher Catcher
+	err := catcher.Do(tc.fn)
+
+	if tc.expectError {
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		if tc.expectPanic {
+			if recovered, ok := err.(Recovered); ok {
+				if recovered.Recovered() == nil {
+					t.Fatalf("expected recovered panic value, got nil")
+				}
+			} else {
+				t.Fatalf("expected Recovered error, got %T", err)
+			}
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+}
+
+func TestCatcherDo(t *testing.T) {
+	for _, tc := range catcherDoTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+type catcherTryTestCase struct {
+	name        string
+	fn          func() error
+	expectError bool
+	expectPanic bool
+}
+
+var catcherTryTestCases = []catcherTryTestCase{
+	{
+		name: "successful function",
+		fn: func() error {
+			return nil
+		},
+		expectError: false,
+		expectPanic: false,
+	},
+	{
+		name: "function returns error",
+		fn: func() error {
+			return errors.New("test error")
+		},
+		expectError: true,
+		expectPanic: false,
+	},
+	{
+		name: "function panics",
+		fn: func() error {
+			panic("test panic")
+		},
+		expectError: false,
+		expectPanic: true,
+	},
+	{
+		name:        "nil function",
+		fn:          nil,
+		expectError: false,
+		expectPanic: false,
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc catcherTryTestCase) test(t *testing.T) {
+	t.Helper()
+	var catcher Catcher
+	err := catcher.Try(tc.fn)
+
+	if tc.expectError {
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+
+	// Check recovered panic
+	recovered := catcher.Recovered()
+	if tc.expectPanic {
+		if recovered == nil {
+			t.Fatalf("expected recovered panic, got nil")
+		}
+	} else {
+		if recovered != nil {
+			t.Fatalf("expected no recovered panic, got %v", recovered)
+		}
+	}
+}
+
+func TestCatcherTry(t *testing.T) {
+	for _, tc := range catcherTryTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestCatcherRecovered(t *testing.T) {
+	var catcher Catcher
+
+	// Initially no panic
+	if recovered := catcher.Recovered(); recovered != nil {
+		t.Fatalf("expected nil recovered, got %v", recovered)
+	}
+
+	// After panic
+	_ = catcher.Try(func() error {
+		panic("test panic")
+	})
+
+	recovered := catcher.Recovered()
+	if recovered == nil {
+		t.Fatalf("expected recovered panic, got nil")
+	}
+
+	// String panics get converted to errors by NewPanicError
+	if err, ok := recovered.Recovered().(error); ok {
+		if err.Error() != "test panic" {
+			t.Fatalf("expected 'test panic', got %v", err.Error())
+		}
+	} else {
+		t.Fatalf("expected error type for string panic, got %T", recovered.Recovered())
+	}
+}
+
+func TestCatcherConcurrent(t *testing.T) {
+	var catcher Catcher
+
+	// Use a channel to coordinate goroutines
+	done := make(chan bool, 2)
+
+	// Test that only the first panic is stored
+	go func() {
+		_ = catcher.Try(func() error {
+			panic("first panic")
+		})
+		done <- true
+	}()
+
+	go func() {
+		_ = catcher.Try(func() error {
+			panic("second panic")
+		})
+		done <- true
+	}()
+
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+
+	recovered := catcher.Recovered()
+	if recovered == nil {
+		t.Fatalf("expected recovered panic, got nil")
+	}
+
+	// Should be either "first panic" or "second panic" (converted to errors)
+	panicValue := recovered.Recovered()
+	if err, ok := panicValue.(error); ok {
+		errorStr := err.Error()
+		if errorStr != "first panic" && errorStr != "second panic" {
+			t.Fatalf("unexpected panic value: %v", errorStr)
+		}
+	} else {
+		t.Fatalf("expected error type for string panic, got %T", panicValue)
+	}
+}
+
+type catchTestCase struct {
+	name        string
+	fn          func() error
+	expectError bool
+}
+
+var catchTestCases = []catchTestCase{
+	{
+		name: "successful function",
+		fn: func() error {
+			return nil
+		},
+		expectError: false,
+	},
+	{
+		name: "function returns error",
+		fn: func() error {
+			return errors.New("test error")
+		},
+		expectError: true,
+	},
+	{
+		name: "function panics",
+		fn: func() error {
+			panic("test panic")
+		},
+		expectError: true,
+	},
+}
+
+func (tc catchTestCase) test(t *testing.T) {
+	t.Helper()
+	err := Catch(tc.fn)
+
+	if tc.expectError {
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+}
+
+func TestCatch(t *testing.T) {
+	for _, tc := range catchTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+type catchWithPanicRecoveryTestCase struct {
+	name  string
+	value any
+}
+
+var catchWithPanicRecoveryTestCases = []catchWithPanicRecoveryTestCase{
+	{"string panic", "string panic"},
+	{"int panic", 42},
+	{"float panic", 3.14},
+	{"error panic", errors.New("error panic")},
+	{"formatted error", errors.New("formatted error")},
+	// Skip slice and map as they are not comparable
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc catchWithPanicRecoveryTestCase) test(t *testing.T) {
+	t.Helper()
+	err := Catch(func() error {
+		panic(tc.value)
+	})
+
+	if err == nil {
+		t.Fatalf("expected error from panic, got nil")
+	}
+
+	if recovered, ok := err.(Recovered); ok {
+		panicValue := recovered.Recovered()
+
+		// Handle string conversion to error by NewPanicError
+		if s, ok := tc.value.(string); ok {
+			if err, ok := panicValue.(error); ok {
+				if err.Error() != s {
+					t.Fatalf("expected panic error '%s', got '%s'", s, err.Error())
+				}
+			} else {
+				t.Fatalf("expected error type for string panic, got %T", panicValue)
+			}
+		} else {
+			if panicValue != tc.value {
+				t.Fatalf("expected panic value %v, got %v", tc.value, panicValue)
+			}
+		}
+	} else {
+		t.Fatalf("expected Recovered error, got %T", err)
+	}
+}
+
+func TestCatchWithPanicRecovery(t *testing.T) {
+	for _, tc := range catchWithPanicRecoveryTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}

--- a/panic_test.go
+++ b/panic_test.go
@@ -179,10 +179,8 @@ func (tc catcherDoTestCase) test(t *testing.T) {
 				t.Fatalf("expected Recovered error, got %T", err)
 			}
 		}
-	} else {
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	} else if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 

--- a/panicerror_test.go
+++ b/panicerror_test.go
@@ -1,0 +1,504 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type panicErrorMethodsTestCase struct {
+	name     string
+	payload  any
+	expected string
+}
+
+var panicErrorMethodsTestCases = []panicErrorMethodsTestCase{
+	{
+		name:     "string payload",
+		payload:  "test error",
+		expected: "test error",
+	},
+	{
+		name:     "error payload",
+		payload:  errors.New("wrapped error"),
+		expected: "wrapped error",
+	},
+	{
+		name:     "int payload",
+		payload:  42,
+		expected: "%!s(int=42)", // Go's %s format for non-string
+	},
+	{
+		name:     "nil payload",
+		payload:  nil,
+		expected: "%!s(<nil>)", // Go's %s format for nil
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc panicErrorMethodsTestCase) test(t *testing.T) {
+	t.Helper()
+	pe := NewPanicError(0, tc.payload)
+
+	// Test Error method
+	errorStr := pe.Error()
+	expectedError := fmt.Sprintf("panic: %s", tc.expected)
+	if errorStr != expectedError {
+		t.Fatalf("expected error '%s', got '%s'", expectedError, errorStr)
+	}
+
+	// Test Recovered method
+	recovered := pe.Recovered()
+	if tc.payload == nil {
+		if recovered != nil {
+			t.Fatalf("expected nil recovered, got %v", recovered)
+		}
+	} else {
+		// For strings, they get converted to errors in NewPanicError
+		if s, ok := tc.payload.(string); ok {
+			if err, ok := recovered.(error); ok {
+				if err.Error() != s {
+					t.Fatalf("expected recovered error '%s', got '%s'", s, err.Error())
+				}
+			} else {
+				t.Fatalf("expected error type for string payload, got %T", recovered)
+			}
+		} else {
+			if recovered != tc.payload {
+				t.Fatalf("expected recovered %v, got %v", tc.payload, recovered)
+			}
+		}
+	}
+
+	// Test CallStack method
+	stack := pe.CallStack()
+	if len(stack) == 0 {
+		t.Fatalf("expected non-empty stack trace")
+	}
+}
+
+type panicErrorUnwrapTestCase struct {
+	name          string
+	payload       any
+	expectUnwrap  bool
+	expectedError string
+}
+
+var panicErrorUnwrapTestCases = []panicErrorUnwrapTestCase{
+	{
+		name:          "error payload",
+		payload:       errors.New("test error"),
+		expectUnwrap:  true,
+		expectedError: "test error",
+	},
+	{
+		name:          "string payload converts to error",
+		payload:       "string error",
+		expectUnwrap:  true,
+		expectedError: "string error",
+	},
+	{
+		name:         "non-error payload",
+		payload:      42,
+		expectUnwrap: false,
+	},
+	{
+		name:         "nil payload",
+		payload:      nil,
+		expectUnwrap: false,
+	},
+}
+
+func (tc panicErrorUnwrapTestCase) test(t *testing.T) {
+	t.Helper()
+	pe := NewPanicError(0, tc.payload)
+	unwrapped := pe.Unwrap()
+
+	if tc.expectUnwrap {
+		if unwrapped == nil {
+			t.Fatalf("expected unwrapped error, got nil")
+		}
+		if unwrapped.Error() != tc.expectedError {
+			t.Fatalf("expected unwrapped error '%s', got '%s'", tc.expectedError, unwrapped.Error())
+		}
+	} else if unwrapped != nil {
+		t.Fatalf("expected nil unwrapped, got %v", unwrapped)
+	}
+}
+
+type newPanicErrorfTestCase struct {
+	name     string
+	format   string
+	args     []any
+	expected string
+}
+
+var newPanicErrorfTestCases = []newPanicErrorfTestCase{
+	{
+		name:     "no args",
+		format:   "simple error",
+		args:     nil,
+		expected: "simple error",
+	},
+	{
+		name:     "with args",
+		format:   "error %d: %s",
+		args:     []any{42, "test"},
+		expected: "error 42: test",
+	},
+	{
+		name:     "with wrapped error",
+		format:   "wrapped: %w",
+		args:     []any{errors.New("original")},
+		expected: "wrapped: original",
+	},
+}
+
+func (tc newPanicErrorfTestCase) test(t *testing.T) {
+	t.Helper()
+	pe := NewPanicErrorf(0, tc.format, tc.args...)
+
+	// Test Error method
+	errorStr := pe.Error()
+	expectedError := fmt.Sprintf("panic: %s", tc.expected)
+	if errorStr != expectedError {
+		t.Fatalf("expected error '%s', got '%s'", expectedError, errorStr)
+	}
+
+	// Test that payload is an error
+	if _, ok := pe.Recovered().(error); !ok {
+		t.Fatalf("expected error payload, got %T", pe.Recovered())
+	}
+}
+
+func runNewPanicWrapTest(t *testing.T) {
+	originalErr := errors.New("original error")
+	note := "wrapped note"
+
+	pe := NewPanicWrap(0, originalErr, note)
+
+	// Test that it wraps the error
+	unwrapped := pe.Unwrap()
+	if unwrapped == nil {
+		t.Fatalf("expected unwrapped error, got nil")
+	}
+
+	// Test error message contains both note and original
+	errorStr := pe.Error()
+	if !strings.Contains(errorStr, note) {
+		t.Fatalf("expected error to contain note '%s', got '%s'", note, errorStr)
+	}
+	if !strings.Contains(errorStr, originalErr.Error()) {
+		t.Fatalf("expected error to contain original error '%s', got '%s'", originalErr.Error(), errorStr)
+	}
+}
+
+func runNewPanicWrapfTest(t *testing.T) {
+	originalErr := errors.New("original error")
+	format := "wrapped %s: %d"
+	args := []any{"note", 42}
+
+	pe := NewPanicWrapf(0, originalErr, format, args...)
+
+	// Test that it wraps the error
+	unwrapped := pe.Unwrap()
+	if unwrapped == nil {
+		t.Fatalf("expected unwrapped error, got nil")
+	}
+
+	// Test error message contains formatted note and original
+	errorStr := pe.Error()
+	if !strings.Contains(errorStr, "wrapped note: 42") {
+		t.Fatalf("expected error to contain formatted note, got '%s'", errorStr)
+	}
+	if !strings.Contains(errorStr, originalErr.Error()) {
+		t.Fatalf("expected error to contain original error '%s', got '%s'", originalErr.Error(), errorStr)
+	}
+}
+
+type panicFunctionsTestCase struct {
+	name     string
+	fn       func()
+	expected any
+}
+
+var panicFunctionsTestCases = []panicFunctionsTestCase{
+	{
+		name: "Panic with string",
+		fn: func() {
+			Panic("test panic")
+		},
+		expected: "test panic",
+	},
+	{
+		name: "Panic with error",
+		fn: func() {
+			Panic(errors.New("test error"))
+		},
+		expected: "test error", // Compare error content as string
+	},
+	{
+		name: "Panicf without args",
+		fn: func() {
+			Panicf("simple panic")
+		},
+		expected: "simple panic",
+	},
+	{
+		name: "Panicf with args",
+		fn: func() {
+			Panicf("panic %d: %s", 42, "test")
+		},
+		expected: "panic 42: test",
+	},
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc panicFunctionsTestCase) test(t *testing.T) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+
+		pe, ok := r.(*PanicError)
+		if !ok {
+			t.Fatalf("expected PanicError, got %T", r)
+		}
+
+		// Handle payload comparison based on type
+		panicValue := pe.Recovered()
+		if s, ok := tc.expected.(string); ok {
+			if err, ok := panicValue.(error); ok {
+				if err.Error() != s {
+					t.Fatalf("expected panic payload error '%s', got '%s'", s, err.Error())
+				}
+			} else {
+				t.Fatalf("expected error payload for string, got %T", panicValue)
+			}
+		} else {
+			// For non-string expected values, compare directly
+			if panicValue != tc.expected {
+				t.Fatalf("expected panic payload %v, got %v", tc.expected, panicValue)
+			}
+		}
+	}()
+
+	tc.fn()
+}
+
+type panicWrapFunctionsTestCase struct {
+	name string
+	fn   func()
+}
+
+//revive:disable-next-line:cognitive-complexity
+func (tc panicWrapFunctionsTestCase) test(t *testing.T, originalErr error) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+
+		pe, ok := r.(*PanicError)
+		if !ok {
+			t.Fatalf("expected PanicError, got %T", r)
+		}
+
+		// Test that it unwraps to something that contains the original error
+		unwrapped := pe.Unwrap()
+		if unwrapped == nil {
+			t.Fatalf("expected unwrapped error, got nil")
+		}
+
+		// Check if we can find the original error in the chain
+		if !errors.Is(unwrapped, originalErr) {
+			t.Fatalf("expected to find original error in chain")
+		}
+	}()
+
+	tc.fn()
+}
+
+type newUnreachableErrorTestCase struct {
+	name       string
+	err        error
+	note       string
+	expectType string
+}
+
+var newUnreachableErrorTestCases = []newUnreachableErrorTestCase{
+	{
+		name:       "nil error, empty note",
+		err:        nil,
+		note:       "",
+		expectType: "PanicError",
+	},
+	{
+		name:       "nil error, with note",
+		err:        nil,
+		note:       "test note",
+		expectType: "PanicError",
+	},
+	{
+		name:       "ErrUnreachable, with note",
+		err:        ErrUnreachable,
+		note:       "test note",
+		expectType: "PanicError",
+	},
+	{
+		name:       "other error, no note",
+		err:        errors.New("other error"),
+		note:       "",
+		expectType: "PanicError",
+	},
+	{
+		name:       "other error, with note",
+		err:        errors.New("other error"),
+		note:       "test note",
+		expectType: "PanicError",
+	},
+}
+
+func (tc newUnreachableErrorTestCase) test(t *testing.T) {
+	t.Helper()
+	result := NewUnreachableError(0, tc.err, tc.note)
+
+	if result == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+
+	// Test that it's a PanicError
+	pe, ok := result.(*PanicError)
+	if !ok {
+		t.Fatalf("expected PanicError, got %T", result)
+	}
+
+	// Test that ErrUnreachable is somewhere in the chain
+	if !errors.Is(result, ErrUnreachable) {
+		t.Fatalf("expected ErrUnreachable in error chain")
+	}
+
+	// Test error message
+	errorStr := result.Error()
+	if errorStr == "" {
+		t.Fatalf("expected non-empty error message")
+	}
+
+	// Test stack trace
+	stack := pe.CallStack()
+	if len(stack) == 0 {
+		t.Fatalf("expected non-empty stack trace")
+	}
+}
+
+func runNewUnreachableErrorfTest(t *testing.T) {
+	err := errors.New("test error")
+	format := "formatted %s: %d"
+	args := []any{"note", 42}
+
+	result := NewUnreachableErrorf(0, err, format, args...)
+
+	if result == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+
+	// Test that it's a PanicError
+	pe, ok := result.(*PanicError)
+	if !ok {
+		t.Fatalf("expected PanicError, got %T", result)
+	}
+
+	// Test that ErrUnreachable is in the chain
+	if !errors.Is(result, ErrUnreachable) {
+		t.Fatalf("expected ErrUnreachable in error chain")
+	}
+
+	// Test that original error is in the chain
+	if !errors.Is(result, err) {
+		t.Fatalf("expected original error in error chain")
+	}
+
+	// Test formatted message
+	errorStr := result.Error()
+	if !strings.Contains(errorStr, "formatted note: 42") {
+		t.Fatalf("expected formatted message in error, got '%s'", errorStr)
+	}
+
+	// Test stack trace
+	stack := pe.CallStack()
+	if len(stack) == 0 {
+		t.Fatalf("expected non-empty stack trace")
+	}
+}
+
+// Main test functions that call the helpers
+func TestPanicErrorMethods(t *testing.T) {
+	for _, tc := range panicErrorMethodsTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestPanicErrorUnwrap(t *testing.T) {
+	for _, tc := range panicErrorUnwrapTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestNewPanicErrorf(t *testing.T) {
+	for _, tc := range newPanicErrorfTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestNewPanicWrap(t *testing.T) {
+	t.Run("NewPanicWrap", runNewPanicWrapTest)
+}
+
+func TestNewPanicWrapf(t *testing.T) {
+	t.Run("NewPanicWrapf", runNewPanicWrapfTest)
+}
+
+func TestPanicFunctions(t *testing.T) {
+	for _, tc := range panicFunctionsTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestPanicWrapFunctions(t *testing.T) {
+	originalErr := errors.New("original error")
+
+	testCases := []panicWrapFunctionsTestCase{
+		{
+			name: "PanicWrap",
+			fn: func() {
+				PanicWrap(originalErr, "wrap note")
+			},
+		},
+		{
+			name: "PanicWrapf",
+			fn: func() {
+				PanicWrapf(originalErr, "wrap %s: %d", "note", 42)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.test(t, originalErr)
+		})
+	}
+}
+
+func TestNewUnreachableError(t *testing.T) {
+	for _, tc := range newUnreachableErrorTestCases {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestNewUnreachableErrorf(t *testing.T) {
+	t.Run("NewUnreachableErrorf", runNewUnreachableErrorfTest)
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for error handling utilities in the core package:

- **panic.go**: Tests for AsRecovered, Catcher, and Catch functions
- **panicerror.go**: Tests for PanicError types and constructors
- **compounderror.go**: Tests for CompoundError aggregation and unwrapping

## Test Coverage

Adds 1,434 lines of test code across 3 test files:
- `panic_test.go` (442 lines)
- `panicerror_test.go` (506 lines) 
- `compounderror_test.go` (486 lines)

## Key Test Areas

### panic.go
- `AsRecovered` function with various panic types
- `Catcher` struct methods and concurrent usage
- `Catch` function with success/failure scenarios
- Proper error wrapping and stack trace capture

### panicerror.go
- `PanicError` methods and serialization
- `NewPanicError*` constructors with various payloads
- `Panic*` functions that emit panics
- `NewUnreachableError*` functions
- Stack trace capture and formatting

### compounderror.go
- Error aggregation and unwrapping
- `CompoundError` methods (Error, Errors, Unwrap, Ok)
- `AppendError` and `Append` functions
- Nil error handling and empty compound errors

## Testing Approach

All tests follow table-driven patterns with method-based test cases for improved maintainability and reduced cognitive complexity.

## Related

Part of comprehensive test coverage improvement initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for compound error handling, covering various scenarios including error aggregation, method chaining, and error string outputs.
  * Introduced extensive tests for panic recovery utilities, ensuring correct behaviour for panic catching, error wrapping, and concurrency safety.
  * Implemented detailed tests for panic error types and related functions, validating error creation, formatting, unwrapping, and stack trace retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->