### PR TITLE
build: update golangci-lint to v2.3.0 and standardise API naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,54 +1,16 @@
+version: "2"
 run:
-  deadline: 5m
   allow-parallel-runners: true
+  timeout: 5m
   modules-download-mode: readonly
-
-linters-settings:
-  govet:
-    enable: [fieldalignment]
-  revive:
-    rules:
-      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
-      #
-      # Rules in addition to the recommended configuration above.
-      #
-      - name: bool-literal-in-expr
-      - name: constant-logical-expr
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - copyloopvar
     - dupl
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -57,7 +19,58 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+  settings:
+    govet:
+      enable:
+        - fieldalignment
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: bool-literal-in-expr
+        - name: constant-logical-expr
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,1 @@
+../internal/build/cspell.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,1 @@
-{
-    "cSpell.words": [
-        "darvaza",
-        "MORFOLOGIK",
-        "Unwrappable"
-    ]
-}
+{}

--- a/AGENT.md
+++ b/AGENT.md
@@ -367,59 +367,25 @@ Configuration is stored in `.golangci.yml` in the project root.
 
 #### Current Configuration Status
 
-The project uses golangci-lint v1.64.8 (pinned to avoid v2 configuration
-issues). The current `.golangci.yml` uses the v1 format that functions
-properly but triggers IDE schema validation warnings:
+The project uses golangci-lint v2.3.0 with full Go 1.23 support.
+The current `.golangci.yml` uses the v2 format:
 
-- ✅ **Functionally works**: All linters and settings are properly applied
-- ✅ **Field alignment enabled**: `govet: enable: [fieldalignment]` works
-- ⚠️ **Schema validation**: IDE expects v2 format, but system uses v1.64
+- ✅ **Functionally works**: All linters and settings are properly applied.
+- ✅ **Field alignment enabled**: `govet: enable: [fieldalignment]` works.
+- ✅ **Schema validation**: Uses proper v2 format with `version: "2"`.
 
-#### Schema Version Compatibility
+#### Configuration Features
 
-**Current v1.64 format (working)**:
+The v2 configuration provides:
 
-```yaml
-linters-settings:
-  govet:
-    enable: [fieldalignment]
-linters:
-  enable:
-    - govet
-```
-
-**v2 format (IDE expects, but system doesn't support)**:
-
-```yaml
-version: "2"
-linters:
-  enable:
-    - govet
-linters-settings:
-  govet:
-    enable: [fieldalignment]
-```
-
-#### Schema Validation Issues
-
-Common IDE diagnostics and their meanings:
-
-1. **Missing property "version"**: IDE schema expects `version: "2"`.
-2. **Property linters-settings is not allowed**: IDE expects v2 structure.
-3. **cSpell warnings**: Linter names are technical terms not in spell-check
-   dictionary.
-
-#### Resolution Status
-
-- **Current priority**: Low - configuration works functionally.
-- **IDE warnings**: Cannot be resolved without upgrading golangci-lint to v2.
-- **System constraint**: Project uses v1.64.8 to avoid v2 configuration issues.
-- **Workaround**: IDE warnings can be ignored as they don't affect
-  functionality.
+- Improved schema validation with proper IDE support.
+- Separate formatters section for gofmt and goimports.
+- Built-in exclusion presets for common false positives.
+- Enhanced exclusion patterns for generated code.
 
 #### Field Alignment Integration
 
-- Always run `make tidy-root` which includes golangci-lint checks
+- Always run `make tidy` which includes golangci-lint checks
 - Field alignment linter is properly configured and working
 - Schema format doesn't affect linting functionality, only IDE validation
 - Technical linter names are added to `internal/build/cspell.json`
@@ -512,9 +478,7 @@ When creating or editing documentation files:
    - If tools aren't found, they're replaced with `true` (no-op).
    - Install tools globally with `pnpm install -g <tool>` if needed.
 
-5. **golangci-lint schema validation**:
-   - IDE warnings about missing `version` field or `linters-settings` placement.
-   - Configuration functions properly despite schema warnings.
-   - Project uses v1.64.8 to avoid v2 configuration format issues.
+5. **golangci-lint configuration**:
+   - Configuration uses v2.3.0 with proper v2 format.
    - System uses pinned version via Makefile `GOLANGCI_LINT_VERSION`.
-   - cSpell warnings for linter names are added to `internal/build/cspell.json`.
+   - Technical linter names are added to `internal/build/cspell.json`.

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ COVERAGE_DIR ?= $(TMPDIR)/coverage
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v1.64.8)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v2.3.0)
 REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v1.7)
 
-GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)
 
 REVIVE_CONF ?= $(TOOLSDIR)/revive.toml

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The `CompoundError` type aggregates multiple errors:
 * Implements both `Unwrap() []error` and `Errors() []error` interfaces.
 * `.AppendError(err)` / `.Append(errs...)` - add errors.
 * `.AsError()` - convert to single error or nil.
-* `.Ok()` - check if no errors.
+* `.OK()` - check if no errors.
 
 ### Panic Handling
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Library, and if something should be on a subdirectory, it shouldn't be here.
 
 Generic type constraints for use with Go generics:
 
-* `Signed` - signed integer types
-* `Unsigned` - unsigned integer types
-* `Integer` - all integer types (signed and unsigned)
-* `Float` - floating-point types
-* `Complex` - complex number types
-* `Bool` - boolean type
-* `String` - string type
-* `Ordered` - types that support ordering operations
+* `Signed` - signed integer types.
+* `Unsigned` - unsigned integer types.
+* `Integer` - all integer types (signed and unsigned).
+* `Float` - floating-point types.
+* `Complex` - complex number types.
+* `Bool` - boolean type.
+* `String` - string type.
+* `Ordered` - types that support ordering operations.
 
 ## Context
 
@@ -52,12 +52,12 @@ Generic type constraints for use with Go generics:
 
 ### IP Address Functions
 
-* `GetIPAddresses()` - get IP addresses as `netip.Addr`
-* `GetNetIPAddresses()` - get IP addresses as `net.IP`
-* `GetStringIPAddresses()` - get IP addresses as strings
-* `AddrFromNetIP(ip)` - convert `net.IP` to `netip.Addr`
-* `ParseAddr(s)` - parse string to `netip.Addr`
-* `ParseNetIP(s)` - parse string to `net.IP`
+* `GetIPAddresses()` - get IP addresses as `netip.Addr`.
+* `GetNetIPAddresses()` - get IP addresses as `net.IP`.
+* `GetStringIPAddresses()` - get IP addresses as strings.
+* `AddrFromNetIP(ip)` - convert `net.IP` to `netip.Addr`.
+* `ParseAddr(s)` - parse string to `netip.Addr`.
+* `ParseNetIP(s)` - parse string to `net.IP`.
 
 ### Host/Port Functions
 
@@ -82,7 +82,7 @@ Generic type constraints for use with Go generics:
 
 ### Interface Functions
 
-* `GetInterfacesNames()` - get network interface names
+* `GetInterfacesNames()` - get network interface names.
 
 ## Generic Utilities
 
@@ -207,13 +207,13 @@ Key distinctions from `IsZero`:
 
 #### Basic Map Functions
 
-* `MapContains[K]()` checks if a map contains a key
-* `MapValue[K,V]()` returns the value for a key, or a fallback value
-* `Keys[K,T]()` returns a slice of the keys in the map
-* `SortedKeys[K,T]()` returns a sorted slice of the keys
-* `SortedValues[K,T]()` returns values sorted by key
-* `SortedValuesCond[K,T]()` returns filtered values sorted by key
-* `SortedValuesUnlikelyCond[K,T]()` like `SortedValuesCond` but more efficient
+* `MapContains[K]()` checks if a map contains a key.
+* `MapValue[K,V]()` returns the value for a key, or a fallback value.
+* `Keys[K,T]()` returns a slice of the keys in the map.
+* `SortedKeys[K,T]()` returns a sorted slice of the keys.
+* `SortedValues[K,T]()` returns values sorted by key.
+* `SortedValuesCond[K,T]()` returns filtered values sorted by key.
+* `SortedValuesUnlikelyCond[K,T]()` like `SortedValuesCond` but more efficient.
 
 #### Map List Operations
 
@@ -235,14 +235,14 @@ Key distinctions from `IsZero`:
 
 Predefined error values for common conditions:
 
-* `ErrNotImplemented` - functionality not yet implemented
-* `ErrTODO` - placeholder for future implementation
-* `ErrExists` - resource already exists
-* `ErrNotExists` - resource does not exist
-* `ErrInvalid` - invalid input or state
-* `ErrUnknown` - unknown or unspecified error
-* `ErrNilReceiver` - method called on nil receiver
-* `ErrUnreachable` - indicates impossible condition
+* `ErrNotImplemented` - functionality not yet implemented.
+* `ErrTODO` - placeholder for future implementation.
+* `ErrExists` - resource already exists.
+* `ErrNotExists` - resource does not exist.
+* `ErrInvalid` - invalid input or state.
+* `ErrUnknown` - unknown or unspecified error.
+* `ErrNilReceiver` - method called on nil receiver.
+* `ErrUnreachable` - indicates impossible condition.
 
 ### Error Wrapping
 
@@ -252,35 +252,35 @@ containers with `Errors() []error`.
 
 Error wrapping functions:
 
-* `Wrap(err, note)` - wrap with simple string note
-* `Wrapf(err, format, args...)` - wrap with formatted note
-* `QuietWrap(err, note)` - wrap without including original error text
-* `Unwrap(err) []error` - extract all sub-errors from wrapped errors
+* `Wrap(err, note)` - wrap with simple string note.
+* `Wrapf(err, format, args...)` - wrap with formatted note.
+* `QuietWrap(err, note)` - wrap without including original error text.
+* `Unwrap(err) []error` - extract all sub-errors from wrapped errors.
 
 ### Compound Errors
 
 The `CompoundError` type aggregates multiple errors:
 
-* Implements both `Unwrap() []error` and `Errors() []error` interfaces
-* `.AppendError(err)` / `.Append(errs...)` - add errors
-* `.AsError()` - convert to single error or nil
-* `.Ok()` - check if no errors
+* Implements both `Unwrap() []error` and `Errors() []error` interfaces.
+* `.AppendError(err)` / `.Append(errs...)` - add errors.
+* `.AsError()` - convert to single error or nil.
+* `.Ok()` - check if no errors.
 
 ### Panic Handling
 
 The `PanicError` type wraps panic values with stack traces:
 
-* `NewPanicError()` / `NewPanicErrorf()` - create panic errors
-* `NewPanicWrap()` / `NewPanicWrapf()` - wrap existing errors as panics
+* `NewPanicError()` / `NewPanicErrorf()` - create panic errors.
+* `NewPanicWrap()` / `NewPanicWrapf()` - wrap existing errors as panics.
 * `Panic()` / `Panicf()` / `PanicWrap()` / `PanicWrapf()` - panic with
-  `PanicError`
+  `PanicError`.
 
 Panic recovery utilities:
 
-* `Recovered` interface - marks errors from recovered panics
-* `AsRecovered(v)` - convert `recover()` result to error
-* `Catcher` type - safely call functions that might panic
-* `Catch(fn)` - execute function, returning error if panic occurs
+* `Recovered` interface - marks errors from recovered panics.
+* `AsRecovered(v)` - convert `recover()` result to error.
+* `Catcher` type - safely call functions that might panic.
+* `Catch(fn)` - execute function, returning error if panic occurs.
 
 ```go
 defer func() {
@@ -294,8 +294,8 @@ defer func() {
 
 For indicating impossible code paths:
 
-* `NewUnreachableError()` - create unreachable error
-* `NewUnreachableErrorf(format, args...)` - create formatted unreachable error
+* `NewUnreachableError()` - create unreachable error.
+* `NewUnreachableErrorf(format, args...)` - create formatted unreachable error.
 
 These create `PanicError` instances with stack traces.
 
@@ -406,23 +406,23 @@ fmt.Printf("Debug stack:%#+v", stack)
 
 Enhanced wait group with error handling:
 
-* `WaitGroup` - wait group that collects errors
-* `.OnError(fn)` - set error handler
-* `.Go(fn)` / `.GoCatch(fn)` - run functions in `goroutines`
-* `.Wait()` - wait for completion
-* `.Err()` - get first error
+* `WaitGroup` - wait group that collects errors.
+* `.OnError(fn)` - set error handler.
+* `.Go(fn)` / `.GoCatch(fn)` - run functions in `goroutines`.
+* `.Wait()` - wait for completion.
+* `.Err()` - get first error.
 
 ### ErrGroup
 
 Context-aware error group with cancellation:
 
-* `ErrGroup` - context-based error group
-* `.SetDefaults()` - configure with defaults
-* `.OnError(fn)` - set error handler
-* `.Cancel()` / `.Context()` - cancellation control
-* `.Go(fn)` / `.GoCatch(fn)` - run functions with context
-* `.Wait()` - wait and return first error
-* `.IsCancelled()` / `.Cancelled()` - check cancellation state
+* `ErrGroup` - context-based error group.
+* `.SetDefaults()` - configure with defaults.
+* `.OnError(fn)` - set error handler.
+* `.Cancel()` / `.Context()` - cancellation control.
+* `.Go(fn)` / `.GoCatch(fn)` - run functions with context.
+* `.Wait()` - wait and return first error.
+* `.IsCancelled()` / `.Cancelled()` - check cancellation state.
 
 ### Deprecated
 

--- a/addrport_test.go
+++ b/addrport_test.go
@@ -11,7 +11,7 @@ type addrPortTestCase struct {
 	name   string
 	input  any
 	want   netip.AddrPort
-	wantOk bool
+	wantOK bool
 }
 
 var addrPortTestCases = []addrPortTestCase{
@@ -20,125 +20,125 @@ var addrPortTestCases = []addrPortTestCase{
 		name:   "direct AddrPort",
 		input:  netip.MustParseAddrPort("192.168.1.1:8080"),
 		want:   netip.MustParseAddrPort("192.168.1.1:8080"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "pointer to AddrPort",
 		input:  addrPortPtr(netip.MustParseAddrPort("10.0.0.1:443")),
 		want:   netip.MustParseAddrPort("10.0.0.1:443"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "zero AddrPort",
 		input:  netip.AddrPort{},
 		want:   netip.AddrPort{},
-		wantOk: true,
+		wantOK: true,
 	},
 	// TCP addresses
 	{
 		name:   "TCPAddr IPv4",
 		input:  &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 8080},
 		want:   netip.MustParseAddrPort("192.168.1.1:8080"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "TCPAddr IPv6",
 		input:  &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443},
 		want:   netip.MustParseAddrPort("[2001:db8::1]:443"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "TCPAddr with zone",
 		input:  &net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 22, Zone: "eth0"},
 		want:   netip.MustParseAddrPort("[fe80::1]:22"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "TCPAddr with nil IP",
 		input:  &net.TCPAddr{IP: nil, Port: 8080},
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "TCPAddr with zero port",
 		input:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		want:   netip.MustParseAddrPort("127.0.0.1:0"),
-		wantOk: true,
+		wantOK: true,
 	},
 	// UDP addresses
 	{
 		name:   "UDPAddr IPv4",
 		input:  &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 53},
 		want:   netip.MustParseAddrPort("192.168.1.1:53"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "UDPAddr IPv6",
 		input:  &net.UDPAddr{IP: net.ParseIP("::1"), Port: 123},
 		want:   netip.MustParseAddrPort("[::1]:123"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "UDPAddr with nil IP",
 		input:  &net.UDPAddr{IP: nil, Port: 53},
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	// Interface types
 	{
 		name:   "type with AddrPort() method",
 		input:  addrPortProvider{netip.MustParseAddrPort("127.0.0.1:9090")},
 		want:   netip.MustParseAddrPort("127.0.0.1:9090"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "type with Addr() method returning TCPAddr",
 		input:  addrProvider{&net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 80}},
 		want:   netip.MustParseAddrPort("10.0.0.1:80"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "type with RemoteAddr() method",
 		input:  remoteAddrProvider{&net.UDPAddr{IP: net.ParseIP("8.8.8.8"), Port: 53}},
 		want:   netip.MustParseAddrPort("8.8.8.8:53"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "type with Addr() returning unsupported type",
 		input:  addrProvider{&net.UnixAddr{Name: "/tmp/socket", Net: "unix"}},
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	// Invalid types
 	{
 		name:   "nil input",
 		input:  nil,
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "string",
 		input:  "192.168.1.1:8080",
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "int",
 		input:  8080,
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "net.IPAddr (no port)",
 		input:  &net.IPAddr{IP: net.ParseIP("192.168.1.1")},
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "empty struct",
 		input:  struct{}{},
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 }
 
@@ -176,8 +176,8 @@ func (tc addrPortTestCase) test(t *testing.T) {
 	t.Helper()
 
 	got, ok := AddrPort(tc.input)
-	if ok != tc.wantOk {
-		t.Errorf("Expected ok=%v, got %v", tc.wantOk, ok)
+	if ok != tc.wantOK {
+		t.Errorf("Expected ok=%v, got %v", tc.wantOK, ok)
 	}
 	if ok && got != tc.want {
 		t.Errorf("Expected %v, got %v", tc.want, got)
@@ -195,7 +195,7 @@ type typeSpecificAddrPortTestCase struct {
 	name   string
 	input  any
 	want   netip.AddrPort
-	wantOk bool
+	wantOK bool
 }
 
 var typeSpecificAddrPortTestCases = []typeSpecificAddrPortTestCase{
@@ -203,43 +203,43 @@ var typeSpecificAddrPortTestCases = []typeSpecificAddrPortTestCase{
 		name:   "AddrPort value",
 		input:  netip.MustParseAddrPort("192.168.1.1:8080"),
 		want:   netip.MustParseAddrPort("192.168.1.1:8080"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "AddrPort pointer",
 		input:  addrPortPtr(netip.MustParseAddrPort("10.0.0.1:443")),
 		want:   netip.MustParseAddrPort("10.0.0.1:443"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "TCPAddr",
 		input:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9000},
 		want:   netip.MustParseAddrPort("127.0.0.1:9000"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "UDPAddr",
 		input:  &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 53},
 		want:   netip.MustParseAddrPort("10.0.0.1:53"),
-		wantOk: true,
+		wantOK: true,
 	},
 	{
 		name:   "TCPAddr with invalid IP",
 		input:  &net.TCPAddr{IP: S[byte](1, 2, 3), Port: 80}, // Invalid IP length
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "UDPAddr with invalid IP",
 		input:  &net.UDPAddr{IP: S[byte](), Port: 80}, // Empty IP
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 	{
 		name:   "unsupported type",
 		input:  "not an address",
 		want:   netip.AddrPort{},
-		wantOk: false,
+		wantOK: false,
 	},
 }
 
@@ -247,8 +247,8 @@ func (tc typeSpecificAddrPortTestCase) test(t *testing.T) {
 	t.Helper()
 
 	got, ok := typeSpecificAddrPort(tc.input)
-	if ok != tc.wantOk {
-		t.Errorf("Expected ok=%v, got %v", tc.wantOk, ok)
+	if ok != tc.wantOK {
+		t.Errorf("Expected ok=%v, got %v", tc.wantOK, ok)
 	}
 	if ok && got != tc.want {
 		t.Errorf("Expected %v, got %v", tc.want, got)

--- a/as_test.go
+++ b/as_test.go
@@ -16,7 +16,7 @@ type asTestCase struct {
 	name string
 
 	// Boolean fields (1 byte) - expected result flags
-	wantOk bool
+	wantOK bool
 }
 
 func (tc asTestCase) test(t *testing.T) {
@@ -26,24 +26,24 @@ func (tc asTestCase) test(t *testing.T) {
 	switch want := tc.want.(type) {
 	case string:
 		got, ok := As[any, string](tc.input)
-		if ok != tc.wantOk {
-			t.Errorf("As() ok = %v, want %v", ok, tc.wantOk)
+		if ok != tc.wantOK {
+			t.Errorf("As() ok = %v, want %v", ok, tc.wantOK)
 		}
 		if got != want {
 			t.Errorf("As() got = %v, want %v", got, want)
 		}
 	case int:
 		got, ok := As[any, int](tc.input)
-		if ok != tc.wantOk {
-			t.Errorf("As() ok = %v, want %v", ok, tc.wantOk)
+		if ok != tc.wantOK {
+			t.Errorf("As() ok = %v, want %v", ok, tc.wantOK)
 		}
 		if got != want {
 			t.Errorf("As() got = %v, want %v", got, want)
 		}
 	case error:
 		got, ok := As[any, error](tc.input)
-		if ok != tc.wantOk {
-			t.Errorf("As() ok = %v, want %v", ok, tc.wantOk)
+		if ok != tc.wantOK {
+			t.Errorf("As() ok = %v, want %v", ok, tc.wantOK)
 		}
 		if ok && got.Error() != want.Error() {
 			t.Errorf("As() got = %v, want %v", got, want)
@@ -51,10 +51,10 @@ func (tc asTestCase) test(t *testing.T) {
 	default:
 		// Test cases where conversion should fail
 		got, ok := As[any, string](tc.input)
-		if ok != tc.wantOk {
-			t.Errorf("As() ok = %v, want %v", ok, tc.wantOk)
+		if ok != tc.wantOK {
+			t.Errorf("As() ok = %v, want %v", ok, tc.wantOK)
 		}
-		if tc.wantOk && got != "" {
+		if tc.wantOK && got != "" {
 			t.Errorf("As() got = %v, want zero value", got)
 		}
 	}
@@ -66,15 +66,15 @@ type asFnTestCase struct {
 	fn     func(any) (string, bool)
 	input  any
 	want   string
-	wantOk bool
+	wantOK bool
 }
 
 func (tc asFnTestCase) test(t *testing.T) {
 	t.Helper()
 
 	got, ok := AsFn(tc.fn, tc.input)
-	if ok != tc.wantOk {
-		t.Errorf("AsFn() ok = %v, want %v", ok, tc.wantOk)
+	if ok != tc.wantOK {
+		t.Errorf("AsFn() ok = %v, want %v", ok, tc.wantOK)
 	}
 	if got != tc.want {
 		t.Errorf("AsFn() got = %v, want %v", got, tc.want)
@@ -203,37 +203,37 @@ func TestAs(t *testing.T) {
 			name:   "string to string",
 			input:  "hello",
 			want:   "hello",
-			wantOk: true,
+			wantOK: true,
 		},
 		{
 			name:   "int to int",
 			input:  42,
 			want:   42,
-			wantOk: true,
+			wantOK: true,
 		},
 		{
 			name:   "error to error",
 			input:  errors.New("test error"),
 			want:   errors.New("test error"),
-			wantOk: true,
+			wantOK: true,
 		},
 		{
 			name:   "int to string fails",
 			input:  42,
 			want:   "",
-			wantOk: false,
+			wantOK: false,
 		},
 		{
 			name:   "nil to string",
 			input:  nil,
 			want:   "",
-			wantOk: false,
+			wantOK: false,
 		},
 		{
 			name:   "nil to error",
 			input:  nil,
 			want:   error(nil),
-			wantOk: false,
+			wantOK: false,
 		},
 	}
 
@@ -257,28 +257,28 @@ func TestAsFn(t *testing.T) {
 			fn:     intToString,
 			input:  42,
 			want:   "42",
-			wantOk: true,
+			wantOK: true,
 		},
 		{
 			name:   "with valid conversion function but wrong type",
 			fn:     intToString,
 			input:  "not an int",
 			want:   "",
-			wantOk: false,
+			wantOK: false,
 		},
 		{
 			name:   "with nil function",
 			fn:     nil,
 			input:  42,
 			want:   "",
-			wantOk: false,
+			wantOK: false,
 		},
 		{
 			name:   "with function returning false",
 			fn:     func(any) (string, bool) { return "ignored", false },
 			input:  42,
 			want:   "ignored",
-			wantOk: false,
+			wantOK: false,
 		},
 	}
 

--- a/compounderror.go
+++ b/compounderror.go
@@ -42,7 +42,19 @@ func (w *CompoundError) Unwrap() []error {
 	return w.Errs
 }
 
+// OK tells when there are no errors stored
+func (w *CompoundError) OK() bool {
+	if w == nil {
+		return true
+	}
+	return len(w.Errs) == 0
+}
+
 // Ok tells when there are no errors stored
+//
+// Deprecated: Use OK() instead.
+//
+//revive:disable-next-line:confusing-naming
 func (w *CompoundError) Ok() bool {
 	return len(w.Errs) == 0
 }

--- a/compounderror_test.go
+++ b/compounderror_test.go
@@ -96,13 +96,13 @@ func TestCompoundErrorUnwrap(t *testing.T) {
 	}
 }
 
-type compoundErrorOkTestCase struct {
+type compoundErrorOKTestCase struct {
 	name     string
 	errs     []error
 	expected bool
 }
 
-var compoundErrorOkTestCases = []compoundErrorOkTestCase{
+var compoundErrorOKTestCases = []compoundErrorOKTestCase{
 	{
 		name:     "empty errors",
 		errs:     S[error](),
@@ -125,20 +125,30 @@ var compoundErrorOkTestCases = []compoundErrorOkTestCase{
 	},
 }
 
-func (tc compoundErrorOkTestCase) test(t *testing.T) {
-	t.Helper()
-	ce := &CompoundError{Errs: tc.errs}
-	result := ce.Ok()
-
-	if result != tc.expected {
-		t.Fatalf("expected %t, got %t", tc.expected, result)
-	}
+func (tc compoundErrorOKTestCase) Name() string {
+	return tc.name
 }
 
-func TestCompoundErrorOk(t *testing.T) {
-	for _, tc := range compoundErrorOkTestCases {
-		t.Run(tc.name, tc.test)
+func (tc compoundErrorOKTestCase) Test(t *testing.T) {
+	t.Helper()
+	ce := &CompoundError{Errs: tc.errs}
+
+	// Test both OK() and deprecated Ok() methods
+	resultOK := ce.OK()
+	resultOk := ce.Ok()
+
+	AssertEqual(t, tc.expected, resultOK, "OK() method")
+	AssertEqual(t, tc.expected, resultOk, "Ok() method")
+	AssertEqual(t, resultOK, resultOk, "OK() and Ok() should return same result")
+}
+
+func TestCompoundErrorOK(t *testing.T) {
+	// Convert to []TestCase for use with RunTestCases
+	testCases := make([]TestCase, len(compoundErrorOKTestCases))
+	for i, tc := range compoundErrorOKTestCases {
+		testCases[i] = tc
 	}
+	RunTestCases(t, testCases)
 }
 
 type compoundErrorAsErrorTestCase struct {

--- a/context_test.go
+++ b/context_test.go
@@ -231,7 +231,7 @@ type contextKeyGetTestCase struct {
 	key           *ContextKey[int]
 	name          string
 	expectedValue int
-	expectedOk    bool
+	expectedOK    bool
 }
 
 func (tc contextKeyGetTestCase) test(t *testing.T) {
@@ -239,17 +239,17 @@ func (tc contextKeyGetTestCase) test(t *testing.T) {
 
 	value, ok := tc.key.Get(tc.ctx)
 	AssertEqual(t, tc.expectedValue, value, "Get returned wrong value")
-	AssertBool(t, ok, tc.expectedOk, "Get returned wrong ok value")
+	AssertBool(t, ok, tc.expectedOK, "Get returned wrong ok value")
 }
 
 func contextKeyGetTest(ctx context.Context, name string, key *ContextKey[int],
-	expectedValue int, expectedOk bool) contextKeyGetTestCase {
+	expectedValue int, expectedOK bool) contextKeyGetTestCase {
 	return contextKeyGetTestCase{
 		ctx:           ctx,
 		key:           key,
 		name:          name,
 		expectedValue: expectedValue,
-		expectedOk:    expectedOk,
+		expectedOK:    expectedOK,
 	}
 }
 

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -37,6 +37,7 @@
     "gofmt",
     "GOFMT",
     "GOGENERATE",
+    "goimports",
     "golangci",
     "golangci-lint",
     "GOPATH",


### PR DESCRIPTION
### **User description**
## Summary

This branch contains multiple improvements to the core library:

- Updates golangci-lint from v1.64.8 to v2.3.0 for Go 1.23 compatibility.
- Standardises method naming by renaming `Ok()` to `OK()` following proper
  camelCase conventions.
- Improves documentation consistency by adding periods to sentence endings
  in README.md.
- Centralises cspell configuration using symbolic links for better
  maintainability.

## Key Changes

### Build System Updates

The golangci-lint upgrade provides full Go 1.23 support and improved
linting performance:

- Migrated .golangci.yml to v2 configuration format using the official
  migration tool.
- Removed deprecated linters: typecheck (now runs automatically) and
  gosimple (removed in v2).
- Moved formatters (gofmt, goimports) to dedicated formatters section.
- Added exclusion presets for common false positives and generated code.
- Updated Makefile to use correct v2 module path and version.

### API Standardisation

Method naming has been standardised to follow Go conventions:

- `CompoundError.Ok()` → `CompoundError.OK()` with backward compatibility.
- Updated all test cases to use the new naming whilst maintaining the
  deprecated method for compatibility.

### Documentation Improvements

- Added periods to all bullet points and sentences in README.md for
  consistency.
- Centralised VS Code cspell configuration using symbolic links to avoid
  duplication.
- Updated AGENT.md to reflect golangci-lint v2 upgrade, removing outdated
  v1.64.8 references and schema validation issues.

## Test Plan

- [x] All existing tests pass with new golangci-lint configuration.
- [x] Backward compatibility maintained for deprecated `Ok()` method.
- [x] Documentation formatting follows project standards.
- [x] Build system works correctly with v2 linter configuration.


___

### **PR Type**
Enhancement


___

### **Description**
- Update golangci-lint from v1.64.8 to v2.3.0

- Standardize API naming: Ok() to OK() method

- Centralize cspell configuration using symlinks

- Improve documentation formatting consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["golangci-lint v1.64.8"] --> B["golangci-lint v2.3.0"]
  C["Ok() method"] --> D["OK() method"]
  E["Inline cspell config"] --> F["Centralized cspell.json"]
  G["Documentation"] --> H["Formatted docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>.golangci.yml</strong><dd><code>Migrate to v2 configuration format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+55/-42</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>settings.json</strong><dd><code>Remove inline cspell configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cspell.json</strong><dd><code>Add symlink to centralized cspell config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-d9f1a54e1f1a4c8324f4756f08a6af27671a3ae9312190d4a5fe981cc1722824">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Update golangci-lint version and module path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>compounderror.go</strong><dd><code>Add OK() method with Ok() deprecation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-dd7600eec8481df6716e956d2869759e30487324cdd878d4f0ecb26f43f39e2c">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>addrport_test.go</strong><dd><code>Fix camelCase: wantOk to wantOK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-dd5888df166db49108980bd2939a91d328863b3b64a998c9508a518c3c642060">+33/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>as_test.go</strong><dd><code>Fix camelCase: wantOk to wantOK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-2bb9510614f1f9ca229f1129aaf952c611523affd3fe5ce0dea3c66c7154ba2d">+23/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>context_test.go</strong><dd><code>Fix camelCase: expectedOk to expectedOK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-e6ce689a25eaef174c2dd51fe869fabbe04a6c6afbd416b23eda138c82e761ba">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>compounderror_test.go</strong><dd><code>Update test cases for OK() method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-098c7bc3ff8b28639254a2ec917c7f34a810189ab1b121014fcc492d5e94f176">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Add periods to sentence endings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+59/-59</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT.md</strong><dd><code>Update golangci-lint documentation for v2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/132/files#diff-c1e87407ce72f38b645f627c7fbda6e6999170c840cded6ce82c1bd2c10923e8">+15/-51</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to check for errors in compound error handling.

- **Bug Fixes**
  - None.

- **Documentation**
  - Updated documentation to reflect the upgrade to the latest version of golangci-lint and improved configuration guidance.
  - Enhanced punctuation and consistency in the README.

- **Style**
  - Standardised naming conventions for boolean fields and test identifiers (e.g., `Ok` → `OK`, `wantOk` → `wantOK`).

- **Chores**
  - Upgraded golangci-lint tool and configuration to version 2, with improved exclusion and formatting settings.
  - Updated VSCode settings for spell checking and workspace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->