### PR TITLE
build: CI improvements and security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
 name: Build
+
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,8 @@
 name: Codecov
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -1,5 +1,8 @@
 name: Race Detection
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,8 @@
 name: renovate-config-validator
+
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,9 +287,9 @@ When LanguageTool reports issues:
 
 ### Field Alignment
 
-The project enforces struct field alignment optimization for memory efficiency
+The project enforces struct field alignment optimisation for memory efficiency
 using the `fieldalignment` tool. This helps reduce memory usage by ordering
-struct fields to minimize padding.
+struct fields to minimise padding.
 
 #### Running Field Alignment Fixes
 
@@ -305,7 +305,7 @@ go run "$FA@latest" -fix ./...
 This tool will:
 
 - Analyze all struct definitions in the project.
-- Reorder fields to minimize memory padding.
+- Reorder fields to minimise memory padding.
 - Automatically update source files with optimized field ordering.
 
 #### Field Alignment Notes
@@ -315,7 +315,7 @@ This tool will:
 - Field alignment changes may require updating struct literal initializations.
 - The tool is safe to run repeatedly - it only makes changes when beneficial.
 - Memory savings can be significant for frequently allocated structs.
-- Run field alignment manually as needed for struct optimization.
+- Run field alignment manually as needed for struct optimisation.
 
 ### golangci-lint Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v2.3.0)
 REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v1.7)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT_RUN_ARGS ?= --show-stats=false
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)
 
 REVIVE_CONF ?= $(TOOLSDIR)/revive.toml
@@ -47,7 +48,13 @@ FIX_WHITESPACE_EXCLUDE_PATTERNS ?= $(patsubst %,-o -name '*.%',$(FIX_WHITESPACE_
 FIX_WHITESPACE_EXCLUDE ?= $(FIX_WHITESPACE_EXCLUDE_GO) $(FIX_WHITESPACE_EXCLUDE_PATTERNS)
 FIX_WHITESPACE_ARGS ?= . \! \( $(FIX_WHITESPACE_EXCLUDE) \)
 
-PNPX ?= pnpx
+ifndef DLX
+ifeq ($(shell pnpm --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+DLX = pnpm dlx
+else
+DLX = true
+endif
+endif
 
 FIND_FILES_PRUNE_RULES ?= -name vendor -o -name .git -o -name node_modules
 FIND_FILES_PRUNE_ARGS ?= \( $(FIND_FILES_PRUNE_RULES) \) -prune
@@ -55,8 +62,8 @@ FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'
 
 ifndef MARKDOWNLINT
-ifeq ($(shell $(PNPX) markdownlint-cli --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
-MARKDOWNLINT = $(PNPX) markdownlint-cli
+ifeq ($(shell $(DLX) markdownlint-cli --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+MARKDOWNLINT = $(DLX) markdownlint-cli
 else
 MARKDOWNLINT = true
 endif
@@ -64,8 +71,8 @@ endif
 MARKDOWNLINT_FLAGS ?= --fix --config $(TOOLSDIR)/markdownlint.json
 
 ifndef LANGUAGETOOL
-ifeq ($(shell $(PNPX) @twilio-labs/languagetool-cli --version 2>&1 | grep -qE '^(unknown|[0-9])' && echo yes),yes)
-LANGUAGETOOL = $(PNPX) @twilio-labs/languagetool-cli
+ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version 2>&1 | grep -qE '^(unknown|[0-9])' && echo yes),yes)
+LANGUAGETOOL = $(DLX) @twilio-labs/languagetool-cli
 else
 LANGUAGETOOL = true
 endif
@@ -73,8 +80,8 @@ endif
 LANGUAGETOOL_FLAGS ?= --config $(TOOLSDIR)/languagetool.cfg --custom-dict-file $(TMPDIR)/languagetool-dict.txt
 
 ifndef CSPELL
-ifeq ($(shell $(PNPX) cspell --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
-CSPELL = $(PNPX) cspell
+ifeq ($(shell $(DLX) cspell --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+CSPELL = $(DLX) cspell
 else
 CSPELL = true
 endif
@@ -82,8 +89,8 @@ endif
 CSPELL_FLAGS ?= --no-progress --dot --config $(TOOLSDIR)/cspell.json
 
 ifndef SHELLCHECK
-ifeq ($(shell $(PNPX) shellcheck --version 2>&1 | grep -q '^ShellCheck' && echo yes),yes)
-SHELLCHECK = $(PNPX) shellcheck
+ifeq ($(shell $(DLX) shellcheck --version 2>&1 | grep -q '^ShellCheck' && echo yes),yes)
+SHELLCHECK = $(DLX) shellcheck
 else
 SHELLCHECK = true
 endif
@@ -155,11 +162,11 @@ tidy: fmt $(TIDY_SPELLING) $(TIDY_SHELL)
 generate: ; $(info $(M) running go:generate…)
 	$Q git grep -l '^//go:generate' | sort -uV | xargs -r -n1 $(GO) generate $(GOGENERATE_FLAGS)
 
+# Prepare for codecov uploading
+codecov: $(COVERAGE_DIR)/coverage.out $(COVERAGE_DIR)/codecov.sh
 
 # Generate Codecov upload script
-# This target prepares codecov.sh script for uploading coverage
-# data to Codecov with proper module flags
-codecov: $(COVERAGE_DIR)/coverage.out ; $(info $(M) preparing codecov data)
+$(COVERAGE_DIR)/codecov.sh: $(TOOLSDIR)/make_codecov.sh $(TMPDIR)/index ; $(info $(M) generating codecov.sh…)
 	$Q $(TOOLSDIR)/make_codecov.sh $(TMPDIR)/index $(COVERAGE_DIR)
 
 check-jq: FORCE

--- a/internal/build/README-coverage.md
+++ b/internal/build/README-coverage.md
@@ -113,7 +113,7 @@ them into a single call. This is intentional because:
 ### Performance Considerations
 
 While separate uploads add ~20 seconds to CI time, this ensures accurate
-coverage tracking. Future optimizations could include:
+coverage tracking. Future optimisations could include:
 
 - Parallel uploads to reduce total time.
 - Skipping modules with no coverage changes.

--- a/internal/build/fix_whitespace.sh
+++ b/internal/build/fix_whitespace.sh
@@ -5,45 +5,90 @@
 # Usage: fix_whitespace.sh [find arguments]
 #        fix_whitespace.sh -- file1 file2 ...
 #
-# Automatically prunes .git and node_modules directories
+# Automatically prunes .git, .tmp and node_modules directories
 #
 # Environment Variables:
 #   SED - sed command to use (default: sed)
-#         Set to "gsed" on macOS or "sed -i ''" for BSD compatibility
+#   JOBS - number of parallel jobs to run (default: 4)
+#   FILES_PER_JOB - number of files per job (default: 4)
 #
 # Examples:
 #   fix_whitespace.sh . -name '*.go' -o -name '*.md'
 #   fix_whitespace.sh src/ -name '*.js'
 #   fix_whitespace.sh -- README.md LICENCE.txt
-#   SED="gsed" fix_whitespace.sh . -name '*.md'
+#   JOBS=8 FILES_PER_JOB=2 fix_whitespace.sh .
 
 set -eu
 
+JOBS="${JOBS:-4}"
+FILES_PER_JOB="${FILES_PER_JOB:-4}"
+
+# get_bytes FILE COUNT
+# COUNT > 0: first COUNT bytes (head)
+# COUNT < 0: last -COUNT bytes (tail)
+# Outputs hex string
+get_bytes() {
+	local file="$1" count="$2"
+
+	case "$count" in
+	-*)
+		tail -c "${count#-}" "$file" ;;
+	*)
+		head -c "$count" "$file" ;;
+	esac | od -An -tx1 | tr -d ' \t\n'
+}
+
+# quote_arg STRING
+# Outputs STRING wrapped in single quotes with embedded quotes escaped
+quote_arg() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+# filter_file FILE COMMAND [ARGS...]
+# Applies filter command to file in-place, preserving permissions
+filter_file() {
+	local file="$1" tmp
+	shift
+
+	tmp=$(mktemp "fix_whitespace.XXXXXX")
+	if "$@" < "$file" > "$tmp"; then
+		chmod --reference="$file" "$tmp"
+		mv "$tmp" "$file"
+	else
+		rm -f "$tmp"
+		return 1
+	fi
+}
+
 # Function to fix a single file
 fix_file() {
-	local file="$1" last_byte
+	local file="$1"
+	local first_bytes last_content
 
 	# Skip if not a regular file
 	[ -f "$file" ] || return 0
 
-	# Remove trailing whitespace
+	# Remove UTF-8 BOM if present (EF BB BF)
+	first_bytes=$(get_bytes "$file" 3)
+	[ "$first_bytes" != "efbbbf" ] || filter_file "$file" tail -c +4
+
+	# Remove trailing whitespace from each line
 	${SED:-sed} -i 's/[[:space:]]*$//' "$file"
 
 	# Leave empty files alone
 	[ -s "$file" ] || return 0
 
-
-	# Check last byte to see if file ends with newline
-	# Use od to get hexadecimal representation of last byte
-	last_byte=$(tail -c 1 "$file" | od -An -tx1 | tr -d ' \t')
-
-	# If last byte is not newline (0x0a), add one
-	if [ "0a" != "$last_byte" ]; then
-		printf '\n' >> "$file"
-	elif [ "$(wc -c < "$file")" -eq 1 ]; then
-		# File only contains a newline, truncate it
+	# Remove trailing empty lines
+	last_content=$(grep -n . "$file" | tail -1 | cut -d: -f1) || last_content=""
+	if [ -z "$last_content" ]; then
+		# No content, truncate
 		: > "$file"
+		return 0
 	fi
+	filter_file "$file" head -n "$last_content"
+
+	# Ensure file ends with exactly one newline
+	[ "$(get_bytes "$file" -1)" = "0a" ] || printf '\n' >> "$file"
 }
 
 # Helper function to run find with auto-pruning
@@ -59,7 +104,7 @@ run_find() {
 			;;
 		*)
 			# Add path with proper escaping for spaces and special chars
-			quoted=$(printf '%s' "$1" | sed -e "s/'/'\\\\''/g" -e "s/^/'/" -e "s/$/'/")
+			quoted=$(quote_arg "$1")
 			paths="${paths:+$paths }$quoted"
 			shift
 			;;
@@ -69,11 +114,11 @@ run_find() {
 	# Wrap user conditions in parentheses if they exist
 	[ $# -eq 0 ] || set -- \( "$@" \)
 	# combine auto-pruning and user conditions
-	set -- \( -name .git -o -name node_modules \) -prune -o "$@" -type f
+	set -- \( -type d \( -name .git -o -name .tmp -o -name node_modules \) \) -prune -o "$@" -type f
 	# combine escaped paths with find options
 	eval "set -- ${paths:-.} \"\$@\""
 
-	find "$@" -print0 | xargs -0 -r "$0" --
+	find "$@" -print0 | xargs -0 -r "-P${JOBS:-4}" "-n${FILES_PER_JOB:-4}" "$0" --
 }
 
 if [ "${1:-}" = "--" ]; then

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -122,7 +122,7 @@ gen_make_targets() {
 		#
 		call="$(cat <<-EOT | packed
 		\$(GO) vet ./...
-		\$(GOLANGCI_LINT) run
+		\$(GOLANGCI_LINT) run \$(GOLANGCI_LINT_RUN_ARGS)
 		\$(REVIVE) \$(REVIVE_RUN_ARGS) ./...
 		EOT
 		)"

--- a/internal/build/markdownlint.json
+++ b/internal/build/markdownlint.json
@@ -24,5 +24,6 @@
   "MD041": true,
   "MD046": true,
   "MD047": true,
+  "MD060": true,
   "MD007": { "indent": 2 }
 }


### PR DESCRIPTION
### **User description**
## Summary

- Add explicit `permissions: contents: read` to all GitHub Actions workflows
  for security hardening
- Replace deprecated `pnpx` with `pnpm dlx` in Makefile tool detection
- Add `GOLANGCI_LINT_RUN_ARGS` to suppress stats output
- Refactor codecov target to avoid duplicate script execution
- Improve `fix_whitespace.sh` with parallel processing and UTF-8 BOM removal

## Details

### CI Security Hardening

Restricts `GITHUB_TOKEN` to read-only access following the principle of least
privilege. Affected workflows: build, codecov, race, renovate, test.

### Makefile Modernization

`pnpx` has been deprecated in favor of `pnpm dlx`. The new `DLX` variable
properly detects pnpm availability and falls back to no-op when unavailable.

### fix_whitespace.sh Improvements

- Parallel file processing via `JOBS` and `FILES_PER_JOB` env vars
  (defaults: 4, 4)
- UTF-8 BOM removal from file start
- Proper trailing empty line removal
- Auto-prune `.tmp` directories
- Refactored helper functions for maintainability

## Test plan

- [x] `make tidy` passes
- [x] `make test` passes
- [x] GitHub Actions workflows execute successfully


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add explicit read-only permissions to all GitHub Actions workflows

- Replace deprecated pnpx with pnpm dlx in Makefile tool detection

- Enhance fix_whitespace.sh with parallel processing and UTF-8 BOM removal

- Refactor codecov target to avoid duplicate script execution

- Add GOLANGCI_LINT_RUN_ARGS to suppress stats output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions<br/>Workflows"] -- "Add permissions<br/>contents: read" --> B["Security<br/>Hardening"]
  C["Makefile"] -- "Replace pnpx<br/>with pnpm dlx" --> D["Tool Detection"]
  C -- "Add GOLANGCI_LINT<br/>RUN_ARGS" --> E["Build Config"]
  F["fix_whitespace.sh"] -- "Add parallel<br/>processing" --> G["Performance"]
  F -- "Add UTF-8 BOM<br/>removal" --> H["File Processing"]
  I["codecov target"] -- "Refactor to avoid<br/>duplication" --> J["Build Efficiency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Add read-only permissions to build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<ul><li>Add explicit <code>permissions: contents: read</code> block<br> <li> Restrict GITHUB_TOKEN to read-only access</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codecov.yml</strong><dd><code>Add read-only permissions to codecov workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codecov.yml

<ul><li>Add explicit <code>permissions: contents: read</code> block<br> <li> Restrict GITHUB_TOKEN to read-only access</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>race.yml</strong><dd><code>Add read-only permissions to race workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/race.yml

<ul><li>Add explicit <code>permissions: contents: read</code> block<br> <li> Restrict GITHUB_TOKEN to read-only access</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-a1501cd3f8cf73008680e5f2725d3c48d0501da0df80d12faad162cc72e517ab">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>renovate.yml</strong><dd><code>Add read-only permissions to renovate workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/renovate.yml

<ul><li>Add explicit <code>permissions: contents: read</code> block<br> <li> Restrict GITHUB_TOKEN to read-only access</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Add read-only permissions to test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yml

<ul><li>Add explicit <code>permissions: contents: read</code> block<br> <li> Restrict GITHUB_TOKEN to read-only access</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Replace pnpx with pnpm dlx and improve build config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Replace deprecated <code>PNPX</code> variable with <code>DLX</code> that detects pnpm <br>availability<br> <li> Add <code>GOLANGCI_LINT_RUN_ARGS</code> to suppress stats output with <br><code>--show-stats=false</code><br> <li> Update all tool invocations (markdownlint, languagetool, cspell, <br>shellcheck) to use <code>DLX</code><br> <li> Refactor codecov target to separate coverage generation from <br>codecov.sh script generation</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+19/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fix_whitespace.sh</strong><dd><code>Add parallel processing and UTF-8 BOM removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/build/fix_whitespace.sh

<ul><li>Add <code>JOBS</code> and <code>FILES_PER_JOB</code> environment variables for parallel <br>processing (defaults: 4, 4)<br> <li> Implement <code>get_bytes()</code> helper to extract hex bytes from file head/tail<br> <li> Implement <code>quote_arg()</code> helper to properly escape shell arguments<br> <li> Implement <code>filter_file()</code> helper to apply filters in-place with temp <br>files<br> <li> Add UTF-8 BOM (EF BB BF) detection and removal from file start<br> <li> Refactor trailing empty line removal logic using grep and dd<br> <li> Update find command to include <code>.tmp</code> in auto-prune directories<br> <li> Pass parallel job arguments to xargs for concurrent file processing</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/core/pull/150/files#diff-d1cd5802a3c6780822a4824f92819901e99dc67febdeb8280f850a24c4c03a38">+64/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: Added read-only repository contents permission to workflows.

* **Build System**
  * Switched to DLX-based tooling invocation, added code coverage preparation and new linting/runtime variables.

* **Code Quality**
  * Improved automated whitespace-fix tooling with parallelism, robust trimming and exact newline handling; generated make targets now include lint runtime arguments; added an extra markdownlint rule.

* **Documentation**
  * Minor spelling and wording tweaks in build/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->