### PR TITLE
build: require Go 1.24+, update x/net to v0.50.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.23', '1.24', '1.25' ]
+        go: [ '1.24', '1.25', '1.26' ]
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: '**/go.sum'
 

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: '**/go.sum'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go-version: ['1.23', '1.24', '1.25']
+        go-version: ['1.24', '1.25', '1.26']
     steps:
     - uses: actions/checkout@v6
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - modernize
     - nakedret
     - prealloc
     - revive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,9 @@ Always run `make tidy` before committing to ensure proper formatting.
 
 ### Testing Patterns
 
-- Table-driven tests are preferred.
+- Table-driven tests via `TestCase` apply when ≥2 rows of shared-shape
+  data feed one assertion path; otherwise write plain test functions.
+  See [TESTING.md](./TESTING.md) for the full decision rule.
 - All testing utilities are public in `testing.go` for external use.
 - Comprehensive coverage for generic functions is expected.
 - Testing utilities log successful assertions for better debugging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ It serves as the base for other darvaza.org projects.
 
 Before starting development, ensure you have:
 
-- Go 1.23 or later installed (check with `go version`).
+- Go 1.24 or later installed (check with `go version`).
 - `make` command available (usually pre-installed on Unix systems).
 - `$GOPATH` configured correctly (typically `~/go`).
 - Git configured for proper line endings.
@@ -138,7 +138,7 @@ Enhanced coverage reporting with monorepo support:
 
 - **Zero dependencies**: Only the Go standard library and minimal golang.org/x
   packages.
-- **Generic programming**: Extensive use of Go 1.23+ generics for type-safe
+- **Generic programming**: Extensive use of Go generics for type-safe
   utilities.
 - **Single package**: Everything is in the `core` package, no subpackages.
 
@@ -185,7 +185,7 @@ For comprehensive testing patterns and assertion function usage, see:
 
 ## Important Notes
 
-- Go 1.23 is the minimum required version.
+- Go 1.24 is the minimum required version.
 - The Makefile dynamically generates rules for subprojects.
 - Tool versions (golangci-lint, revive) are selected based on Go version.
 - This is a utility library - no business logic, only reusable helpers.
@@ -270,7 +270,7 @@ The project uses DeepSource for static code analysis. Configuration is in the
 
 - **Codecov workflow**: Automatically runs on push/PR to generate coverage
   reports.
-- **Make workflow**: Tests across Go versions 1.23 and 1.24.
+- **Make workflow**: Tests across Go versions 1.24, 1.25 and 1.26.
 - All CI checks must pass before merging PRs.
 
 ### Working with Build Tools
@@ -324,7 +324,7 @@ Configuration is stored in `.golangci.yml` in the project root.
 
 #### Current Configuration Status
 
-The project uses golangci-lint v2.3.0 with full Go 1.23 support.
+The project uses golangci-lint v2.8.0 (Go 1.24) and v2.11.4 (Go 1.25+).
 The current `.golangci.yml` uses the v2 format:
 
 - ✅ **Functionally works**: All linters and settings are properly applied.
@@ -436,6 +436,6 @@ When creating or editing documentation files:
    - Install tools globally with `pnpm install -g <tool>` if needed.
 
 5. **golangci-lint configuration**:
-   - Configuration uses v2.3.0 with proper v2 format.
+   - Configuration uses v2.8.0+ with proper v2 format.
    - System uses pinned version via Makefile `GOLANGCI_LINT_VERSION`.
    - Technical linter names are added to `internal/build/cspell.json`.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -225,7 +225,7 @@ trim_trailing_whitespace = false
 
 Comprehensive Go code analysis:
 
-- Uses golangci-lint v2.3.0+ with v2 configuration format.
+- Uses golangci-lint v2.8.0+ with v2 configuration format.
 - Enables 15+ linters including `fieldalignment`, `revive`, `staticcheck`.
 - Configures revive with 20+ specific rules.
 - Excludes generated code and common false positives.
@@ -282,7 +282,7 @@ Tools are auto-detected and replaced with `true` (no-op) if unavailable.
 
 #### Required Tools
 
-- **Go 1.23+**: Required for `go -C` directory changes.
+- **Go 1.24+**: Required minimum (bumped for golang.org/x/net v0.50.0).
 - **golangci-lint**: Go code linting (version selected by Go version).
 - **revive**: Additional Go linting rules.
 - **make**: Build orchestration.
@@ -304,7 +304,7 @@ The coverage system provides comprehensive testing:
 
 GitHub Actions workflows provide:
 
-- **Build Testing**: Tests across Go 1.23 and 1.24.
+- **Build Testing**: Tests across Go 1.24, 1.25 and 1.26.
 - **Race Detection**: Dedicated workflow for race condition testing.
 - **Coverage Reporting**: Automatic Codecov uploads.
 - **Dependency Updates**: Automated Renovate PRs.
@@ -478,7 +478,7 @@ The build system integrates with development environments:
 
 GitHub Actions workflows provide:
 
-- **Multi-version Testing**: Go 1.23 and 1.24.
+- **Multi-version Testing**: Go 1.24, 1.25 and 1.26.
 - **Coverage Reporting**: Automatic Codecov uploads.
 - **Dependency Management**: Renovate integration.
 - **Branch Protection**: WIP branch exclusion.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ COVERAGE_DIR ?= $(TMPDIR)/coverage
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v2.3.0)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.23 v1.7)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 v2.8.0 v2.11.4)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 v1.14.0 v1.15.0)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT_RUN_ARGS ?= --show-stats=false

--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ Context-aware error group with cancellation:
 
 ## Development
 
-**Requirements:** Go 1.23 or later
+**Requirements:** Go 1.24 or later
 
 For detailed development setup, build commands, and AI agent guidance:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,28 +27,22 @@ compliant test code that meets our strict linting requirements.
 
 ## When to Use TestCase Interface
 
-**ONLY use TestCase for table-driven tests with multiple data cases testing
-the same function logic.**
+A TestCase exists when you have **≥2 rows of shared-shape data feeding one
+assertion path**. Each row differs only in its field values; every row runs
+through the same `Test` body.
 
-**Use TestCase when:**
+Anything else is a plain `func TestFoo(t *testing.T)`:
 
-- Testing a single function with multiple input/output combinations.
-- All test cases share identical test logic.
-- You have 2 or more data variations for the same test behaviour.
+- Single case — not a table.
+- Per-row custom logic — use `t.Run` with named helper functions instead.
+- Differing assertions between rows — split into separate tests.
+- Test operation held inside a struct field (e.g. `fn func() bool`) —
+  that is the test body, not data. Closure fields are acceptable only
+  when they represent fixtures or expected-value computation consumed
+  by a shared `Test` body.
 
-**Examples of appropriate TestCase usage:**
-
-- URL parsing with different input formats.
-- Mathematical functions with various numeric inputs.
-- Validation functions with different valid/invalid inputs.
-- String processing with multiple text variations.
-
-**Do NOT use TestCase when:**
-
-- Testing different functions or methods.
-- Test cases require different validation logic.
-- Testing different behaviours or scenarios.
-- You only have one test case.
+If unsure, write the plain test function first; promote to TestCase only
+when a second row with the same shape forces the question.
 
 ## When to Use t.Run() with Named Functions
 
@@ -74,26 +68,29 @@ func TestUserManager(t *testing.T) {
 }
 ```
 
-## MANDATORY TestCase Compliance Requirements
+## Structure Once You've Chosen TestCase
 
-**When using TestCase interface for table-driven tests, ALL files must meet
-these 6 requirements:**
+Once the decision above qualifies the test as a genuine TestCase, the
+following structural requirements apply:
 
-1. **TestCase Interface Validations**: `var _ TestCase = ...` declarations
-   for all test case types.
-2. **Factory Functions**: All TestCase types have `newTestCaseTypeName()`
-   functions (enables field alignment + logical parameters).
-3. **Factory Usage**: All test case declarations use factory functions
-   (no naked struct literals).
-4. **RunTestCases Usage**: Test functions use `RunTestCases(t, cases)`
-   instead of manual loops.
-5. **Anonymous Functions**: No `t.Run("name", func(t *testing.T) { ... })`
-   patterns longer than 3 lines.
-6. **Test Case List Factories**: Complex test case lists use
-   `myFooTestCases()` factory functions.
+1. **Interface Validation**: `var _ TestCase = ...` declarations for every
+   test case type.
+2. **Factory Functions**: `newTestCaseTypeName()` for every TestCase type
+   (decouples logical parameter order from memory-optimised field
+   alignment).
+3. **Factory Usage**: Declare cases via factories, never naked struct
+   literals.
+4. **RunTestCases**: Invoke the suite through `RunTestCases(t, cases)`; no
+   manual `for _, tc := range ...` loops.
+5. **Anonymous Functions**: Keep `t.Run` bodies to ≤3 lines; extract
+   longer ones into named helper functions.
+6. **List Factories**: Use `myFooTestCases()` factory functions for
+   complex list generation.
 
-These requirements apply **ONLY** to table-driven tests using TestCase, not
-to standard t.Run() patterns.
+These are structural, not decisive: they tell you how to shape a TestCase,
+not whether to use one. Passing this checklist on a single-case TestCase
+or a TestCase whose `fn` field holds the operation under test still means
+the wrong tool was picked.
 
 ## Testing Utilities
 
@@ -1061,6 +1058,13 @@ var testUsers = []User{
 ### ❌ Never Use These Patterns
 
 ```go
+// DON'T: Single-case TestCase — write a plain test function instead.
+
+// DON'T: Hold the operation under test inside a struct field
+// (e.g. fn func() bool with Test: AssertFalse(t, tc.fn(), ...)).
+// Closure fields are data only when they produce a fixture or
+// expected value consumed by a shared Test body.
+
 // DON'T: Anonymous functions >3 lines
 t.Run("test", func(t *testing.T) {
     setup()

--- a/addrport_test.go
+++ b/addrport_test.go
@@ -255,32 +255,28 @@ func TestAddrPortIPv4Handling(t *testing.T) {
 // Benchmarks
 func BenchmarkAddrPortDirect(b *testing.B) {
 	ap := netip.MustParseAddrPort("192.168.1.1:8080")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AddrPort(ap)
 	}
 }
 
 func BenchmarkAddrPortPointer(b *testing.B) {
 	ap := addrPortPtr(netip.MustParseAddrPort("192.168.1.1:8080"))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AddrPort(ap)
 	}
 }
 
 func BenchmarkAddrPortTCPAddr(b *testing.B) {
 	addr := &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 8080}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AddrPort(addr)
 	}
 }
 
 func BenchmarkAddrPortInterface(b *testing.B) {
 	provider := addrPortProvider{netip.MustParseAddrPort("192.168.1.1:8080")}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AddrPort(provider)
 	}
 }

--- a/addrs.go
+++ b/addrs.go
@@ -105,6 +105,7 @@ func AddrFromNetIP(addr net.Addr) (netip.Addr, bool) {
 		s = v.IP
 	case *net.IPNet:
 		s = v.IP
+	default:
 	}
 
 	ipAddr, ok := netip.AddrFromSlice(s)

--- a/addrs_test.go
+++ b/addrs_test.go
@@ -425,7 +425,7 @@ func testExclusionRemovesInterfaces(t *testing.T) {
 
 // Test internal helper functions
 func TestAsStringIPAddresses(t *testing.T) {
-	addrs := S[netip.Addr](
+	addrs := S(
 		netip.MustParseAddr("192.168.1.1"),
 		netip.MustParseAddr("2001:db8::1"),
 		netip.Addr{}, // Invalid address
@@ -441,7 +441,7 @@ func TestAsStringIPAddresses(t *testing.T) {
 }
 
 func TestAsNetIPAddresses(t *testing.T) {
-	addrs := S[netip.Addr](
+	addrs := S(
 		netip.MustParseAddr("192.168.1.1"),
 		netip.MustParseAddr("2001:db8::1"),
 		netip.Addr{},                              // Invalid address
@@ -523,27 +523,26 @@ func TestAppendNetIPAsIP(t *testing.T) {
 
 // Benchmarks
 func BenchmarkParseAddr(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = ParseAddr("192.168.1.1")
 	}
 }
 
 func BenchmarkParseNetIP(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = ParseNetIP("192.168.1.1")
 	}
 }
 
 func BenchmarkGetStringIPAddresses(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetStringIPAddresses()
 	}
 }
 
 func BenchmarkAddrFromNetIP(b *testing.B) {
 	addr := &net.IPAddr{IP: net.ParseIP("192.168.1.1")}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AddrFromNetIP(addr)
 	}
 }

--- a/as_test.go
+++ b/as_test.go
@@ -378,6 +378,8 @@ func TestSliceAsFn(t *testing.T) {
 }
 
 func TestAsError(t *testing.T) {
+	var typedNil *typedNilError
+
 	testCases := []asErrorTestCase{
 		newAsErrorTestCase("standard error", errors.New("standard error"), "standard error", true),
 		newAsErrorTestCase("nil error", error(nil), "", false),
@@ -391,6 +393,7 @@ func TestAsError(t *testing.T) {
 		newAsErrorTestCase("non-error type", "not an error", "", false),
 		newAsErrorTestCase("nil value", nil, "", false),
 		newAsErrorTestCase("integer", 42, "", false),
+		newAsErrorTestCase("typed-nil error", error(typedNil), "", false),
 	}
 
 	RunTestCases(t, testCases)
@@ -497,3 +500,8 @@ func TestSliceAsFnEdgeCases(t *testing.T) {
 
 	_ = SliceAsFn(panicFn, S[any]("will panic"))
 }
+
+// Custom error type used by the typed-nil AsError case in TestAsError.
+type typedNilError struct{}
+
+func (*typedNilError) Error() string { return "typed-nil" }

--- a/as_test.go
+++ b/as_test.go
@@ -492,7 +492,7 @@ func TestSliceAsFnEdgeCases(t *testing.T) {
 	// Verify panic propagates
 	defer func() {
 		if r := recover(); r == nil {
-			t.Errorf("SliceAsFn with panic function should panic")
+			t.Error("SliceAsFn with panic function should panic")
 		}
 	}()
 

--- a/as_test.go
+++ b/as_test.go
@@ -427,7 +427,7 @@ func TestAsErrors(t *testing.T) {
 // Benchmark tests
 func BenchmarkAs(b *testing.B) {
 	input := "test string"
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = As[any, string](input)
 	}
 }
@@ -439,7 +439,7 @@ func BenchmarkAsFn(b *testing.B) {
 	}
 	var input any = "test string"
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = AsFn(fn, input)
 	}
 }
@@ -447,8 +447,7 @@ func BenchmarkAsFn(b *testing.B) {
 func BenchmarkSliceAs(b *testing.B) {
 	input := S[any]("a", 1, "b", 2, "c", 3, "d", 4, "e", 5)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = SliceAs[any, string](input)
 	}
 }
@@ -456,7 +455,7 @@ func BenchmarkSliceAs(b *testing.B) {
 func BenchmarkAsError(b *testing.B) {
 	err := errors.New("test error")
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = AsError(err)
 	}
 }

--- a/compounderror.go
+++ b/compounderror.go
@@ -117,6 +117,7 @@ func (w *CompoundError) Append(err error, note string, args ...any) *CompoundErr
 	case note != "":
 		// wrap
 		err = Wrap(err, note)
+	default:
 	}
 
 	w.Errs = append(w.Errs, err)

--- a/compounderror_test.go
+++ b/compounderror_test.go
@@ -470,3 +470,9 @@ func TestCompoundErrorIsInterface(t *testing.T) {
 		return
 	}
 }
+
+// Test OK() on a nil receiver — should report true.
+func TestCompoundErrorNilOK(t *testing.T) {
+	var ce *CompoundError
+	AssertTrue(t, ce.OK(), "nil CompoundError.OK")
+}

--- a/context.go
+++ b/context.go
@@ -21,6 +21,7 @@ func (ck *ContextKey[T]) WithValue(ctx context.Context, v T) context.Context {
 	switch ctx {
 	case nil, context.TODO():
 		ctx = context.Background()
+	default:
 	}
 
 	return context.WithValue(ctx, ck, v)

--- a/errgroup_test.go
+++ b/errgroup_test.go
@@ -12,6 +12,7 @@ var (
 	_ TestCase = errGroupSetDefaultsTestCase{}
 	_ TestCase = errGroupGoTestCase{}
 	_ TestCase = errGroupGoCatchTestCase{}
+	_ TestCase = errGroupErrTestCase{}
 )
 
 type errGroupSetDefaultsTestCase struct {
@@ -540,4 +541,44 @@ func TestErrGroupWithCustomParent(t *testing.T) {
 	if err == nil {
 		t.Error("Expected timeout error from parent context")
 	}
+}
+
+// errGroupErrTestCase covers ErrGroup.Err() across the pristine and
+// worker-error branches. A nil workerErr means no worker is launched
+// and Err() should return nil; a non-nil workerErr is returned by the
+// launched worker and Err() should propagate it.
+type errGroupErrTestCase struct {
+	workerErr error
+	name      string
+}
+
+func newErrGroupErrTestCase(name string, workerErr error) errGroupErrTestCase {
+	return errGroupErrTestCase{name: name, workerErr: workerErr}
+}
+
+func (tc errGroupErrTestCase) Name() string { return tc.name }
+
+func (tc errGroupErrTestCase) Test(t *testing.T) {
+	t.Helper()
+	var eg ErrGroup
+	if tc.workerErr != nil {
+		eg.Go(func(_ context.Context) error { return tc.workerErr }, nil)
+		_ = eg.Wait()
+	}
+	if tc.workerErr == nil {
+		AssertNil(t, eg.Err(), tc.name)
+		return
+	}
+	AssertSame(t, tc.workerErr, eg.Err(), tc.name)
+}
+
+func errGroupErrTestCases() []errGroupErrTestCase {
+	return []errGroupErrTestCase{
+		newErrGroupErrTestCase("pristine", nil),
+		newErrGroupErrTestCase("worker error", errors.New("worker")),
+	}
+}
+
+func TestErrGroupErr(t *testing.T) {
+	RunTestCases(t, errGroupErrTestCases())
 }

--- a/errgroup_test.go
+++ b/errgroup_test.go
@@ -451,8 +451,7 @@ func TestErrGroupConcurrency(t *testing.T) {
 
 func startConcurrentWorkers(t *testing.T, eg *ErrGroup, numWorkers int) {
 	t.Helper()
-	for i := 0; i < numWorkers; i++ {
-		worker := i
+	for worker := range numWorkers {
 		eg.Go(createConcurrentWorker(worker), nil)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"slices"
 )
 
 var (
@@ -118,6 +119,7 @@ func (w *TemporaryError) Error() string {
 		return ""
 	case w.cause != nil:
 		cause = w.cause.Error()
+	default:
 	}
 
 	switch {
@@ -198,6 +200,7 @@ func Unwrap(err error) []error {
 		Unwrap() error
 	}:
 		errs = append(errs, w.Unwrap())
+	default:
 	}
 
 	return SliceReplaceFn(errs, func(_ []error, err error) (error, bool) {
@@ -216,12 +219,7 @@ func IsError(err error, errs ...error) bool {
 	}
 
 	fn := func(err error) bool {
-		for _, e := range errs {
-			if err == e {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(errs, err)
 	}
 
 	return IsErrorFn(fn, err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -150,12 +150,7 @@ func (tc quietWrapTestCase) Name() string {
 func (tc quietWrapTestCase) Test(t *testing.T) {
 	t.Helper()
 
-	var result error
-	if len(tc.args) > 0 {
-		result = QuietWrap(tc.err, tc.format, tc.args...)
-	} else {
-		result = QuietWrap(tc.err, tc.format)
-	}
+	result := QuietWrap(tc.err, tc.format, tc.args...)
 
 	if tc.expected == "" {
 		AssertEqual(t, tc.err, result, "QuietWrap original")

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,6 +17,8 @@ var _ TestCase = checkIsTemporaryTestCase{}
 var _ TestCase = isTemporaryTestCase{}
 var _ TestCase = checkIsTimeoutTestCase{}
 var _ TestCase = isTimeoutTestCase{}
+var _ TestCase = wrappedErrorTestCase{}
+var _ TestCase = unwrapBranchesTestCase{}
 
 const emptyString = ""
 
@@ -395,6 +397,8 @@ func checkIsTemporaryTestCases() []checkIsTemporaryTestCase {
 		newCheckIsTemporaryTestCase("temporary error", tempErr, true, true),
 		newCheckIsTemporaryTestCase("timeout error", timeoutErr, true, true),
 		newCheckIsTemporaryTestCase("regular error", regularErr, false, false),
+		newCheckIsTemporaryTestCase("IsTemporary-only interface",
+			&isTemporaryOnlyError{}, true, true),
 	)
 }
 
@@ -486,6 +490,8 @@ func checkIsTimeoutTestCases() []checkIsTimeoutTestCase {
 		newCheckIsTimeoutTestCase("temporary error", tempErr, false, true),
 		newCheckIsTimeoutTestCase("timeout error", timeoutErr, true, true),
 		newCheckIsTimeoutTestCase("regular error", regularErr, false, false),
+		newCheckIsTimeoutTestCase("IsTimeout-only interface",
+			&isTimeoutOnlyError{}, true, true),
 	)
 }
 
@@ -537,4 +543,118 @@ func isTimeoutTestCases() []isTimeoutTestCase {
 // Test IsTimeout function (0% coverage)
 func TestIsTimeout(t *testing.T) {
 	RunTestCases(t, isTimeoutTestCases())
+}
+
+// emptyMessageError returns "" from Error() so that WrappedError.Error()
+// takes the `s == ""` branch and falls back to the wrapper's note.
+type emptyMessageError struct{}
+
+func (emptyMessageError) Error() string { return "" }
+
+// Types that implement only one of Unwrap/Errors/IsTemporary/IsTimeout
+// to exercise the non-first branches of the type switches.
+type errorsOnlyError struct{ errs []error }
+
+func (*errorsOnlyError) Error() string     { return "errors-only" }
+func (e *errorsOnlyError) Errors() []error { return e.errs }
+
+type singleUnwrapError struct{ inner error }
+
+func (*singleUnwrapError) Error() string   { return "single-unwrap" }
+func (e *singleUnwrapError) Unwrap() error { return e.inner }
+
+type isTemporaryOnlyError struct{}
+
+func (*isTemporaryOnlyError) Error() string     { return "is-temporary-only" }
+func (*isTemporaryOnlyError) IsTemporary() bool { return true }
+
+type isTimeoutOnlyError struct{}
+
+func (*isTimeoutOnlyError) Error() string   { return "is-timeout-only" }
+func (*isTimeoutOnlyError) IsTimeout() bool { return true }
+
+// wrappedErrorTestCase exercises WrappedError.Error and Unwrap,
+// including the typed-nil receiver and empty-cause fallback branches.
+type wrappedErrorTestCase struct {
+	err        *WrappedError
+	wantUnwrap error
+	name       string
+	wantError  string
+}
+
+func newWrappedErrorTestCase(name string, err *WrappedError,
+	wantError string, wantUnwrap error) wrappedErrorTestCase {
+	return wrappedErrorTestCase{
+		err:        err,
+		name:       name,
+		wantError:  wantError,
+		wantUnwrap: wantUnwrap,
+	}
+}
+
+func (tc wrappedErrorTestCase) Name() string { return tc.name }
+
+func (tc wrappedErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+	AssertEqual(t, tc.wantError, tc.err.Error(), "WrappedError.Error")
+	if tc.wantUnwrap == nil {
+		AssertNil(t, tc.err.Unwrap(), "WrappedError.Unwrap")
+		return
+	}
+	AssertErrorIs(t, tc.err.Unwrap(), tc.wantUnwrap, "WrappedError.Unwrap")
+}
+
+func wrappedErrorTestCases() []wrappedErrorTestCase {
+	empty := emptyMessageError{}
+	return S(
+		newWrappedErrorTestCase("nil receiver", nil, "", nil),
+		newWrappedErrorTestCase("empty cause",
+			&WrappedError{cause: empty, note: "note"}, "note", empty),
+	)
+}
+
+// Cover WrappedError method behaviour across its main branches.
+func TestWrappedError(t *testing.T) {
+	RunTestCases(t, wrappedErrorTestCases())
+}
+
+// unwrapBranchesTestCase covers the three Unwrap type-switch arms plus
+// the default branch, asserting that the returned slice contains the
+// expected inner error(s).
+type unwrapBranchesTestCase struct {
+	err       error
+	name      string
+	wantInner []error
+}
+
+func newUnwrapBranchesTestCase(name string, err error,
+	wantInner []error) unwrapBranchesTestCase {
+	return unwrapBranchesTestCase{err: err, name: name, wantInner: wantInner}
+}
+
+func (tc unwrapBranchesTestCase) Name() string { return tc.name }
+
+func (tc unwrapBranchesTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := Unwrap(tc.err)
+	AssertSliceEqual(t, tc.wantInner, got, "Unwrap")
+}
+
+func unwrapBranchesTestCases() []unwrapBranchesTestCase {
+	inner := errors.New("inner")
+	return S(
+		newUnwrapBranchesTestCase("Unwrap []error branch",
+			&CompoundError{Errs: []error{inner}}, []error{inner}),
+		newUnwrapBranchesTestCase("Errors() branch",
+			&errorsOnlyError{errs: []error{inner}}, []error{inner}),
+		newUnwrapBranchesTestCase("Unwrap error branch",
+			&singleUnwrapError{inner: inner}, []error{inner}),
+		newUnwrapBranchesTestCase("default branch",
+			errors.New("plain"), nil),
+	)
+}
+
+// Test Unwrap(err) hits all three type-switch branches and the default.
+func TestUnwrapBranches(t *testing.T) {
+	RunTestCases(t, unwrapBranchesTestCases())
 }

--- a/generics_test.go
+++ b/generics_test.go
@@ -429,30 +429,30 @@ func evaluateNoFunction(called *bool) int {
 // Benchmark tests
 func BenchmarkCoalesceInt(b *testing.B) {
 	inputs := S(0, 0, 0, 42, 0, 100)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Coalesce(inputs...)
 	}
 }
 
 func BenchmarkCoalesceString(b *testing.B) {
 	inputs := S("", "", "", "hello", "", "world")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Coalesce(inputs...)
 	}
 }
 
 func BenchmarkIIfInt(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		_ = IIf(i%2 == 0, 42, 100)
+		i++
 	}
 }
 
 func BenchmarkIIfString(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		_ = IIf(i%2 == 0, "hello", "world")
+		i++
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module darvaza.org/core
 
-go 1.23.0
+go 1.24.0
 
-require golang.org/x/net v0.43.0
+require golang.org/x/net v0.50.0
 
-require golang.org/x/text v0.28.0 // indirect
+require golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
-golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
+golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=

--- a/internal/build/README-coverage.md
+++ b/internal/build/README-coverage.md
@@ -2,6 +2,12 @@
 
 This document explains the coverage testing setup for monorepos.
 
+## Related Documentation
+
+- [BUILDING.md](../../BUILDING.md) - Shared build system architecture and
+  usage.
+- [AGENTS.md](../../AGENTS.md) - Development workflow and tooling guidance.
+
 ## Overview
 
 The coverage system is designed to handle multiple Go modules in a monorepo,
@@ -30,9 +36,8 @@ This script:
 
 - Reads the module index.
 - Runs `go test -coverprofile -coverpkg=./... ./...` for each module using
-  `go -C` to change directory (requires Go 1.23+). This tests all packages
-  recursively and instruments all packages for coverage, not just those with
-  test files.
+  `go -C` to change directory. This tests all packages recursively and
+  instruments all packages for coverage, not just those with test files.
 - Shows progress with module name and directory.
 - Generates individual coverage files with pattern `coverage_${name}.prof`.
 - Creates multiple output formats: `.prof`, `.func`, `.html`, and `.stdout`.

--- a/lists_test.go
+++ b/lists_test.go
@@ -9,6 +9,7 @@ import (
 var (
 	_ TestCase = listContainsTestCase{}
 	_ TestCase = listCopyTestCase{}
+	_ TestCase = listForEachTypeMismatchTestCase{}
 )
 
 func testListIteration(t *testing.T, name string, iterFn func(*list.List, func(int) bool), values, expected []int) {
@@ -481,4 +482,48 @@ func testListForEachBackwardElementNilAndEarlyReturn(t *testing.T, name string,
 	iterFn func(*list.List, func(*list.Element) bool)) {
 	t.Helper()
 	testListForEachElementNilAndEarlyReturn(t, name, iterFn)
+}
+
+type listForEachTypeMismatchTestCase struct {
+	list *list.List
+	iter func(*list.List, func(int) bool)
+	name string
+	want []int
+}
+
+func (tc listForEachTypeMismatchTestCase) Name() string { return tc.name }
+
+func (tc listForEachTypeMismatchTestCase) Test(t *testing.T) {
+	t.Helper()
+	collected := make([]int, 0, len(tc.want))
+	tc.iter(tc.list, func(v int) bool {
+		collected = append(collected, v)
+		return false
+	})
+	AssertSliceEqual(t, tc.want, collected, tc.name)
+}
+
+func newListForEachTypeMismatchTestCase(name string, l *list.List,
+	iter func(*list.List, func(int) bool), want []int) listForEachTypeMismatchTestCase {
+	return listForEachTypeMismatchTestCase{
+		name: name,
+		list: l,
+		iter: iter,
+		want: want,
+	}
+}
+
+// Cover the type-mismatch branch in ListForEach/Backward: elements whose
+// Value is not of type T are silently skipped (inner closure returns false
+// to continue iteration).
+func TestListForEachTypeMismatch(t *testing.T) {
+	l := list.New()
+	l.PushBack(1)
+	l.PushBack("not-an-int")
+	l.PushBack(3)
+
+	RunTestCases(t, []listForEachTypeMismatchTestCase{
+		newListForEachTypeMismatchTestCase("forward", l, ListForEach[int], S(1, 3)),
+		newListForEachTypeMismatchTestCase("backward", l, ListForEachBackward[int], S(3, 1)),
+	})
 }

--- a/maps.go
+++ b/maps.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"container/list"
+	"slices"
 )
 
 // Keys returns the list of keys of a map
@@ -16,16 +17,7 @@ func Keys[K comparable, T any](m map[K]T) []K {
 // SortedKeys returns a sorted list of the keys of a map
 func SortedKeys[K Ordered, T any](m map[K]T) []K {
 	keys := Keys(m)
-	SliceSort(keys, func(a, b K) int {
-		switch {
-		case a == b:
-			return 0
-		case a < b:
-			return -1
-		default:
-			return 1
-		}
-	})
+	slices.Sort(keys)
 	return keys
 }
 

--- a/maps_test.go
+++ b/maps_test.go
@@ -216,7 +216,7 @@ func TestSortedValuesUnlikelyCond(t *testing.T) {
 	AssertEqual(t, 0, len(got2), "SortedValuesUnlikelyCond empty")
 
 	// Test nil map
-	got3 := SortedValuesUnlikelyCond[string, int](nil, predicate)
+	got3 := SortedValuesUnlikelyCond[string](nil, predicate)
 	AssertNil(t, got3, "SortedValuesUnlikelyCond(nil)")
 
 	// Test nil predicate
@@ -753,26 +753,24 @@ func TestMapListEdgeCases(t *testing.T) {
 // Benchmark tests
 func BenchmarkKeys(b *testing.B) {
 	m := make(map[string]int)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key := fmt.Sprintf("key%d", i)
 		m[key] = i
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Keys(m)
 	}
 }
 
 func BenchmarkSortedKeys(b *testing.B) {
 	m := make(map[string]int)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key := fmt.Sprintf("key%d", i)
 		m[key] = i
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = SortedKeys(m)
 	}
 }
@@ -780,20 +778,20 @@ func BenchmarkSortedKeys(b *testing.B) {
 func BenchmarkMapListAppend(b *testing.B) {
 	m := make(map[string]*list.List)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		MapListAppend(m, "key", i)
+		i++
 	}
 }
 
 func BenchmarkMapListContains(b *testing.B) {
 	m := make(map[string]*list.List)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		MapListAppend(m, "key", i)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = MapListContains(m, "key", 50)
 	}
 }

--- a/panicerror.go
+++ b/panicerror.go
@@ -125,6 +125,7 @@ func NewUnreachableError(skip int, err error, note string) error {
 		return NewPanicWrap(skip+1, ErrUnreachable, note)
 	case note != "":
 		err = Wrap(err, note)
+	default:
 	}
 
 	return NewPanicError(skip+1, &CompoundError{

--- a/panicerror_test.go
+++ b/panicerror_test.go
@@ -120,7 +120,7 @@ func (tc panicErrorUnwrapTestCase) Test(t *testing.T) {
 
 	if tc.expectUnwrap {
 		if unwrapped == nil {
-			t.Fatalf("expected unwrapped error, got nil")
+			t.Fatal("expected unwrapped error, got nil")
 		}
 		if unwrapped.Error() != tc.expectedError {
 			t.Fatalf("expected unwrapped error '%s', got '%s'", tc.expectedError, unwrapped.Error())
@@ -194,7 +194,7 @@ func runNewPanicWrapTest(t *testing.T) {
 	// Test that it wraps the error
 	unwrapped := pe.Unwrap()
 	if unwrapped == nil {
-		t.Fatalf("expected unwrapped error, got nil")
+		t.Fatal("expected unwrapped error, got nil")
 	}
 
 	// Test error message contains both note and original
@@ -217,7 +217,7 @@ func runNewPanicWrapfTest(t *testing.T) {
 	// Test that it wraps the error
 	unwrapped := pe.Unwrap()
 	if unwrapped == nil {
-		t.Fatalf("expected unwrapped error, got nil")
+		t.Fatal("expected unwrapped error, got nil")
 	}
 
 	// Test error message contains formatted note and original
@@ -389,7 +389,7 @@ func (tc newUnreachableErrorTestCase) Test(t *testing.T) {
 	result := NewUnreachableError(0, tc.err, tc.note)
 
 	if result == nil {
-		t.Fatalf("expected non-nil error, got nil")
+		t.Fatal("expected non-nil error, got nil")
 	}
 
 	// Test that it's a PanicError
@@ -400,19 +400,19 @@ func (tc newUnreachableErrorTestCase) Test(t *testing.T) {
 
 	// Test that ErrUnreachable is somewhere in the chain
 	if !errors.Is(result, ErrUnreachable) {
-		t.Fatalf("expected ErrUnreachable in error chain")
+		t.Fatal("expected ErrUnreachable in error chain")
 	}
 
 	// Test error message
 	errorStr := result.Error()
 	if errorStr == "" {
-		t.Fatalf("expected non-empty error message")
+		t.Fatal("expected non-empty error message")
 	}
 
 	// Test stack trace
 	stack := pe.CallStack()
 	if len(stack) == 0 {
-		t.Fatalf("expected non-empty stack trace")
+		t.Fatal("expected non-empty stack trace")
 	}
 }
 
@@ -434,7 +434,7 @@ func runNewUnreachableErrorfTest(t *testing.T) {
 	result := NewUnreachableErrorf(0, err, format, args...)
 
 	if result == nil {
-		t.Fatalf("expected non-nil error, got nil")
+		t.Fatal("expected non-nil error, got nil")
 	}
 
 	// Test that it's a PanicError
@@ -445,12 +445,12 @@ func runNewUnreachableErrorfTest(t *testing.T) {
 
 	// Test that ErrUnreachable is in the chain
 	if !errors.Is(result, ErrUnreachable) {
-		t.Fatalf("expected ErrUnreachable in error chain")
+		t.Fatal("expected ErrUnreachable in error chain")
 	}
 
 	// Test that original error is in the chain
 	if !errors.Is(result, err) {
-		t.Fatalf("expected original error in error chain")
+		t.Fatal("expected original error in error chain")
 	}
 
 	// Test formatted message
@@ -462,7 +462,7 @@ func runNewUnreachableErrorfTest(t *testing.T) {
 	// Test stack trace
 	stack := pe.CallStack()
 	if len(stack) == 0 {
-		t.Fatalf("expected non-empty stack trace")
+		t.Fatal("expected non-empty stack trace")
 	}
 }
 

--- a/slices.go
+++ b/slices.go
@@ -3,7 +3,7 @@ package core
 import (
 	"crypto/rand"
 	"math/big"
-	"sort"
+	"slices"
 )
 
 // SliceMinus returns a new slice containing only the
@@ -252,28 +252,28 @@ func SliceSortFn[T any](x []T, less func(a, b T) bool) {
 // a > b and zero when a == b.
 func SliceSort[T any](x []T, cmp func(a, b T) int) {
 	if cmp != nil && len(x) > 0 {
-		doSliceSort(x, func(a, b T) bool {
-			return cmp(a, b) < 0
-		})
+		slices.SortFunc(x, cmp)
 	}
 }
 
 // SliceSortOrdered sorts the slice x of an [Ordered] type in ascending order.
 func SliceSortOrdered[T Ordered](x []T) {
 	if len(x) > 0 {
-		doSliceSort(x, func(a, b T) bool {
-			return a < b
-		})
+		slices.Sort(x)
 	}
 }
 
 func doSliceSort[T any](x []T, less func(a, b T) bool) {
-	s := sortable[T]{
-		x:    x,
-		less: less,
-	}
-
-	sort.Sort(s)
+	slices.SortFunc(x, func(a, b T) int {
+		switch {
+		case less(a, b):
+			return -1
+		case less(b, a):
+			return 1
+		default:
+			return 0
+		}
+	})
 }
 
 // SliceP returns the p-th percentile element from a slice.
@@ -316,32 +316,6 @@ func doP[T any](x []T, p float64, less func(a, b T) bool) T {
 	idx := max(int(float64(n)*p+0.5)-1, 0)
 
 	return x[idx]
-}
-
-var _ sort.Interface = sortable[any]{}
-
-type sortable[T any] struct {
-	// Function pointer - ordered alphabetically
-	less func(a, b T) bool
-
-	// Slice - ordered alphabetically
-	x []T
-}
-
-func (s sortable[T]) Len() int {
-	return len(s.x)
-}
-
-func (s sortable[T]) Less(i, j int) bool {
-	// this is only accessible from sort.Sort() so
-	// we can trust the indexes
-	return s.less(s.x[i], s.x[j])
-}
-
-func (s sortable[T]) Swap(i, j int) {
-	// this is only accessible from sort.Sort() so
-	// we can trust the indexes
-	s.x[j], s.x[i] = s.x[i], s.x[j]
 }
 
 // SliceReverse modifies a slice reversing the order of its

--- a/slices_test.go
+++ b/slices_test.go
@@ -21,6 +21,7 @@ var (
 	_ TestCase = slicePIntTestCase{}
 	_ TestCase = slicePFloatTestCase{}
 	_ TestCase = slicePStringTestCase{}
+	_ TestCase = sliceReplaceFnNilFnTestCase{}
 )
 
 type sliceReverseTestCase struct {
@@ -761,4 +762,48 @@ func TestSliceP(t *testing.T) {
 	RunTestCases(t, slicePIntTestCases())
 	RunTestCases(t, slicePFloatTestCases())
 	RunTestCases(t, slicePStringTestCases())
+}
+
+// Cover the short-circuit branches of SliceEqual/SliceEqualFn.
+func TestSliceEqualShortCircuits(t *testing.T) {
+	a := S(1, 2, 3)
+	b := S(1, 2)
+	AssertFalse(t, SliceEqual(a, b), "different lengths")
+	AssertFalse(t, SliceEqualFn(a, b, func(x, y int) bool { return x == y }),
+		"SliceEqualFn different lengths")
+	AssertFalse(t, SliceEqualFn(a, a, nil), "SliceEqualFn nil comparator")
+	AssertFalse(t, SliceEqual(S(1, 2, 3), S(1, 2, 4)), "values differ")
+}
+
+// Cover nil-pointer early-returns and nil-fn NO-OP in slice helpers.
+func TestSliceUniquifyNilPtr(t *testing.T) {
+	result := SliceUniquify[int](nil)
+	AssertEqual(t, 0, len(result), "SliceUniquify nil ptr returns empty slice")
+
+	result = SliceUniquifyFn[int](nil, func(x, y int) bool { return x == y })
+	AssertEqual(t, 0, len(result), "SliceUniquifyFn nil ptr returns empty slice")
+}
+
+type sliceReplaceFnNilFnTestCase struct {
+	name string
+	in   []int
+}
+
+func (tc sliceReplaceFnNilFnTestCase) Name() string { return tc.name }
+
+func (tc sliceReplaceFnNilFnTestCase) Test(t *testing.T) {
+	t.Helper()
+	result := SliceReplaceFn(tc.in, nil)
+	AssertSliceEqual(t, tc.in, result, "SliceReplaceFn nil fn is NO-OP")
+}
+
+func newSliceReplaceFnNilFnTestCase(name string, in []int) sliceReplaceFnNilFnTestCase {
+	return sliceReplaceFnNilFnTestCase{name: name, in: in}
+}
+
+func TestSliceReplaceFnNilFn(t *testing.T) {
+	RunTestCases(t, []sliceReplaceFnNilFnTestCase{
+		newSliceReplaceFnNilFnTestCase("non-empty", S(1, 2, 3)),
+		newSliceReplaceFnNilFnTestCase("empty", S[int]()),
+	})
 }

--- a/spinlock_test.go
+++ b/spinlock_test.go
@@ -210,7 +210,7 @@ func TestSpinLockConcurrency(t *testing.T) {
 	var counter int64
 
 	err := RunConcurrentTest(t, numGoroutines, func(_ int) error {
-		for j := 0; j < numIterations; j++ {
+		for range numIterations {
 			sl.Lock()
 			counter++
 			sl.Unlock()
@@ -233,7 +233,7 @@ func BenchmarkSpinLockUncontended(b *testing.B) {
 		if !ok {
 			b.Fatal("invalid data type")
 		}
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			sl.Lock()
 			// Do minimal work while holding the lock
 			_ = runtime.NumGoroutine()
@@ -259,11 +259,11 @@ func runContentionBenchmark(b *testing.B, sl *SpinLock) {
 	numWorkers := runtime.NumCPU()
 	iterations := b.N / numWorkers
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+			for range iterations {
 				sl.Lock()
 				_ = runtime.NumGoroutine()
 				sl.Unlock()

--- a/splithostport.go
+++ b/splithostport.go
@@ -59,6 +59,7 @@ func doMakeHostPort(host, port string, defaultPort uint16) (string, error) {
 		ok = true
 	case port != "0":
 		ok = true
+	default:
 	}
 
 	hostPort := host + ":" + port
@@ -252,6 +253,7 @@ func splitHostPortUnsafe(hostPort string) (host, port string, err error) {
 	case host == "":
 		// :port
 		host = "::" // use undetermined host
+	default:
 	}
 
 	return host, port, err

--- a/splithostport_test.go
+++ b/splithostport_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 )
 
@@ -27,14 +28,18 @@ func (tc splitAddrPortCase) Name() string {
 	return tc.name
 }
 
+func (tc splitAddrPortCase) matches(a netip.Addr, p uint16, err error) bool {
+	if err != nil {
+		return !tc.ok && !a.IsValid() && p == 0
+	}
+	return tc.ok && a.String() == tc.addr && p == tc.port
+}
+
 func (tc splitAddrPortCase) Test(t *testing.T) {
 	t.Helper()
 
 	a, p, err := SplitAddrPort(tc.addrPort)
-	if err != nil && !tc.ok {
-		// failed as expected
-		t.Logf("SplitAddrPort(%q) -> %q, %q, %#v", tc.addrPort, a.String(), p, err)
-	} else if a.String() != tc.addr || p != tc.port || (err == nil) != tc.ok {
+	if !tc.matches(a, p, err) {
 		// unexpected result
 		t.Errorf("SplitAddrPort(%q) -> %q, %q, %#v", tc.addrPort, a.String(), p, err)
 	} else {

--- a/splithostport_test.go
+++ b/splithostport_test.go
@@ -74,6 +74,9 @@ func splitAddrPortTestCases() []splitAddrPortCase {
 		newSplitAddrPortCase("incomplete bracketed IPv6", "[::1:1234", "", 0, false),
 		newSplitAddrPortCase("bracketed IPv6 and port", "[::1]:1234", "::1", 1234, true),
 		newSplitAddrPortCase("IPv6 port out of range", "[::1]:123456", "", 0, false),
+		// A valid port but a host that isn't a literal IP forces
+		// ParseAddr to fail, covering the non-IP address branch.
+		newSplitAddrPortCase("hostname not IP", "name:1234", "", 0, false),
 	)
 }
 
@@ -144,6 +147,9 @@ func splitHostPortTestCases() []splitHostPortCase {
 		newSplitHostPortCase("puny code", "hello.xn--rhqv96g", "hello.\u4E16\u754C", "", true),
 		newSplitHostPortCase("good name", "good.name", "good.name", "", true),
 		newSplitHostPortCase("no host bad port", ":port", "", "", false),
+		// Trailing garbage after `]` exercises the default branch of
+		// splitHostPortBracketed.
+		newSplitHostPortCase("bracketed IPv6 trailing garbage", "[::1]x", "", "", false),
 	)
 }
 

--- a/stack.go
+++ b/stack.go
@@ -192,6 +192,7 @@ func (f Frame) Format(s fmt.State, verb rune) {
 		f.formatFile(s)
 		writeFormat(s, ":")
 		f.formatLine(s)
+	default:
 	}
 }
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ var _ TestCase = frameFormatTestCase{}
 var _ TestCase = stackFormatTestCase{}
 var _ TestCase = formatLineTestCase{}
 var _ TestCase = writeFormatTestCase{}
+var _ TestCase = writeFormatPanicsTestCase{}
 
 const (
 	MaxTestDepth = 16
@@ -528,6 +530,8 @@ func frameFormatTestCases() []frameFormatTestCase {
 		newFrameFormatTestCase("empty name %n", emptyFrame, "%n", ""),
 		newFrameFormatTestCase("empty file:line %v", emptyFrame, "%v", ":0"),
 		newFrameFormatTestCase("empty file:line with # flag %#v", emptyFrame, "%#v", ":0"),
+		// Unknown verbs fall through to the empty default branch.
+		newFrameFormatTestCase("unknown verb %x", frame, "%x", ""),
 	)
 }
 
@@ -700,4 +704,61 @@ func writeFormatTestCases() []writeFormatTestCase {
 // Test writeFormat error conditions for better coverage (60% -> higher)
 func TestWriteFormatEdgeCases(t *testing.T) {
 	RunTestCases(t, writeFormatTestCases())
+}
+
+// failingWriter returns a fixed (n, err) from every Write.
+type failingWriter struct {
+	err error
+	n   int
+}
+
+func (w failingWriter) Write(_ []byte) (int, error) { return w.n, w.err }
+
+// writeFormatPanicsTestCase exercises the two panic paths in writeFormat:
+// Write error and short write. The wantPanic substring identifies which
+// branch triggered the panic.
+type writeFormatPanicsTestCase struct {
+	w         io.Writer
+	name      string
+	wantPanic string
+}
+
+func newWriteFormatPanicsTestCase(name string, w io.Writer,
+	wantPanic string) writeFormatPanicsTestCase {
+	return writeFormatPanicsTestCase{name: name, w: w, wantPanic: wantPanic}
+}
+
+func (tc writeFormatPanicsTestCase) Name() string { return tc.name }
+
+func (tc writeFormatPanicsTestCase) Test(t *testing.T) {
+	t.Helper()
+	AssertPanic(t, func() { writeFormat(tc.w, "payload") }, tc.wantPanic, tc.name)
+}
+
+func writeFormatPanicsTestCases() []writeFormatPanicsTestCase {
+	return S(
+		newWriteFormatPanicsTestCase("write error",
+			failingWriter{err: io.ErrShortWrite}, `Frame: failed to write "payload"`),
+		// len("payload") == 7, so n=3 is a short write.
+		newWriteFormatPanicsTestCase("short write",
+			failingWriter{n: 3}, "Frame: incomplete write (3/7)"),
+	)
+}
+
+func TestWriteFormatPanics(t *testing.T) {
+	RunTestCases(t, writeFormatPanicsTestCases())
+}
+
+// Cover the unknown-PC branch of frameForPC: passing pc=0 makes
+// frameForPC call runtime.FuncForPC(pc - 1), which returns nil and
+// forces the "unknown" fallback.
+func TestFrameForPCUnknown(t *testing.T) {
+	f := frameForPC(0)
+	AssertEqual(t, "unknown", f.Name(), "unknown PC name")
+	AssertEqual(t, "unknown", f.File(), "unknown PC file")
+}
+
+// Cover the early-return branch of StackFrame when skip exceeds depth.
+func TestStackFrameSkipExceeds(t *testing.T) {
+	AssertNil(t, StackFrame(10000), "StackFrame returns nil when skip > depth")
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -27,7 +27,7 @@ func TestHere(t *testing.T) {
 	if s := fmt.Sprintf("%n", Here()); s != "TestHere" {
 		t.FailNow()
 	}
-	for i := 0; i < MaxDepth; i++ {
+	for i := range MaxDepth {
 		f := deepHere(i)
 		if s := fmt.Sprintf("%n", f); s != "hereHere" {
 			t.FailNow()
@@ -52,8 +52,8 @@ func TestStackFrame(t *testing.T) {
 		t.FailNow()
 	}
 
-	for i := 0; i < MaxTestDepth; i++ {
-		for j := 0; j < MaxTestSpace; j++ {
+	for i := range MaxTestDepth {
+		for j := range MaxTestSpace {
 			f := deepStackFrame(i, j)
 			if s := fmt.Sprintf("%n", f); s != "hereStackFrame" {
 				log.Print(s)

--- a/stack_test.go
+++ b/stack_test.go
@@ -166,6 +166,7 @@ func analyzeFrame(analysis *stackAnalysis, frame Frame, position int, expectatio
 		}
 	case expectation.recurringFunc:
 		analysis.recurringCount++
+	default:
 	}
 }
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -443,15 +443,15 @@ func TestAssertNoPanic(t *testing.T) {
 // Test RunConcurrentTest
 func TestRunConcurrentTest(t *testing.T) {
 	mock := &MockT{}
-	var counter int64
+	var counter atomic.Int64
 
 	// Test successful concurrent execution
 	err := RunConcurrentTest(mock, 5, func(_ int) error {
-		atomic.AddInt64(&counter, 1)
+		counter.Add(1)
 		return nil
 	})
 	AssertNoError(t, err, "RunConcurrentTest successful")
-	AssertEqual(t, int64(5), atomic.LoadInt64(&counter), "all workers executed")
+	AssertEqual(t, int64(5), counter.Load(), "all workers executed")
 
 	// Test concurrent execution with error
 	err = RunConcurrentTest(mock, 3, func(id int) error {

--- a/testing_test.go
+++ b/testing_test.go
@@ -704,6 +704,7 @@ func testMockTConcurrent(t *testing.T) {
 			mock.Errorf("concurrent error %d", id)
 		case 4:
 			mock.Logf("concurrent log %d", id)
+		default:
 		}
 		return nil
 	})

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -319,9 +319,9 @@ func TestWaitGroupConcurrency(t *testing.T) {
 	var counter int64
 	var mu sync.Mutex
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		wg.Go(func() error {
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				mu.Lock()
 				counter++
 				mu.Unlock()

--- a/zero.go
+++ b/zero.go
@@ -344,6 +344,7 @@ func isSamePointer(va, vb reflect.Value) bool {
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.Bool:
 		ok = va.Interface() == vb.Interface()
+	default:
 	}
 	return ok
 }

--- a/zero_test.go
+++ b/zero_test.go
@@ -602,7 +602,7 @@ func testIsNilSlices(t *testing.T) {
 	AssertTrue(t, IsNil(vi), "interface containing typed nil")
 
 	// Slice of pointers with nil elements
-	var ptrSlice []*int
+	ptrSlice := make([]*int, 0, 1)
 	ptrSlice = append(ptrSlice, nil)
 	AssertFalse(t, IsNil(ptrSlice), "slice containing nil elements")
 	AssertTrue(t, IsNil(ptrSlice[0]), "nil element in slice")

--- a/zero_test.go
+++ b/zero_test.go
@@ -1284,13 +1284,13 @@ func isSameStackOverflowTestCases() []isSameStackOverflowTestCase {
 		// Deeply nested interfaces
 		newIsSameStackOverflowTestCase("different deep nested chains", func() (any, any) {
 			var current1 any = 42
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				next := current1
 				current1 = &next
 			}
 
 			var current2 any = 42
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				next := current2
 				current2 = &next
 			}
@@ -1300,7 +1300,7 @@ func isSameStackOverflowTestCases() []isSameStackOverflowTestCase {
 
 		newIsSameStackOverflowTestCase("same deep nested chain", func() (any, any) {
 			var current any = 42
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				next := current
 				current = &next
 			}

--- a/zero_test.go
+++ b/zero_test.go
@@ -18,6 +18,7 @@ var _ TestCase = isNilVsIsZeroTestCase{}
 var _ TestCase = initializationSemanticsTestCase{}
 var _ TestCase = isSameTestCase{}
 var _ TestCase = isSameStackOverflowTestCase{}
+var _ TestCase = isZeroCustomInterfaceTestCase{}
 
 type zeroTestCase[T comparable] struct {
 	expected T
@@ -934,6 +935,13 @@ func isSameValueTypeTestCases() []isSameTestCase {
 			"same floats should be same"),
 		newIsSameTestCase("different floats", 3.14, 2.71, false,
 			"different floats should not be same"),
+		// Arrays and structs have no pointer-based sameness; both fall
+		// through to the empty default branch of isSamePointer.
+		newIsSameTestCase("same arrays", [2]int{1, 2}, [2]int{1, 2}, false,
+			"arrays fall through to the default branch"),
+		newIsSameTestCase("same structs",
+			struct{ X int }{X: 1}, struct{ X int }{X: 1}, false,
+			"structs fall through to the default branch"),
 	)
 }
 
@@ -1416,4 +1424,39 @@ func isSameComplexTestCases() []isSameTestCase {
 
 func TestIsSameStackOverflow(t *testing.T) {
 	RunTestCases(t, isSameStackOverflowTestCases())
+}
+
+// Custom type that implements IsZero() bool for the interface branch.
+type hasIsZeroType struct {
+	zero bool
+}
+
+func (h hasIsZeroType) IsZero() bool { return h.zero }
+
+type isZeroCustomInterfaceTestCase struct {
+	name string
+	in   hasIsZeroType
+	want bool
+}
+
+func (tc isZeroCustomInterfaceTestCase) Name() string { return tc.name }
+
+func (tc isZeroCustomInterfaceTestCase) Test(t *testing.T) {
+	t.Helper()
+	AssertEqual(t, tc.want, IsZero(tc.in), tc.name)
+}
+
+func newIsZeroCustomInterfaceTestCase(name string, in hasIsZeroType,
+	want bool) isZeroCustomInterfaceTestCase {
+	return isZeroCustomInterfaceTestCase{name: name, in: in, want: want}
+}
+
+// Cover the `interface{ IsZero() bool }` branch of IsZero.
+func TestIsZeroCustomInterface(t *testing.T) {
+	RunTestCases(t, []isZeroCustomInterfaceTestCase{
+		newIsZeroCustomInterfaceTestCase("custom IsZero returns true",
+			hasIsZeroType{zero: true}, true),
+		newIsZeroCustomInterfaceTestCase("custom IsZero returns false",
+			hasIsZeroType{zero: false}, false),
+	})
 }


### PR DESCRIPTION
# Bump minimum Go to 1.24, update x/net to v0.50.0

## Summary

- Raise the project floor to Go 1.24 and shift the CI matrix to
  `{1.24, 1.25, 1.26}`.
- Update `golang.org/x/net` to **v0.50.0** — the last release whose
  `go.mod` still declares `go 1.24.0`; v0.51.0+ requires Go 1.25.
- Tier `golangci-lint` and `revive` pins in the Makefile so each Go
  version picks a compatible tool release.
- Apply the code-quality fixes surfaced by the newer linters across
  the core source tree.
- Enable golangci-lint's `modernize` analyzer so future regressions
  to pre-1.22 / pre-1.24 idioms get caught in CI.
- Tighten `TESTING.md` / `AGENTS.md` so the `TestCase` decision rule
  (≥2 rows of shared-shape data) comes before the structural
  checklist.
- Close line-coverage gaps uncovered by CI after the refactor.

## Commits

### 1. `refactor: clean up switch and test style across core`

Applies independently of the version bump — the changes are valid
against the current 1.23 floor / v1.7 revive and would land cleanly
either way. Bundled here because the newer linters flag them.

- `default:` clauses added to non-exhaustive switches
  (`addrs.go`, `compounderror.go`, `context.go`, `errors.go`,
  `panicerror.go`, `splithostport.go`, `stack.go`, `zero.go`,
  `stack_test.go`, `testing_test.go`).
- `slices.go`: replace `sort.Sort` + `sortable` adapter with
  `slices.SortFunc`; drop the now-unused helper type.
- `maps.go`: replace the `SliceSort` + comparator callback in
  `SortedKeys` with `slices.Sort` (minimum Go is now 1.24).
- `errors.go`: collapse the `IsError` inner loop to
  `slices.Contains`.
- `panicerror_test.go`, `as_test.go`: `Fatalf`/`Errorf` → `Fatal`/
  `Error` where no format args are passed.
- `splithostport_test.go`: extract `splitAddrPortCase.matches`
  helper to collapse the two identical log branches.
- `zero_test.go`: preallocate `ptrSlice` (prealloc).
- `errors_test.go`: simplify `quietWrapTestCase.Test` to a single
  `QuietWrap(err, format, args...)` pass-through, dropping the
  if/else that split the no-args and variadic cases.

### 2. `build: raise minimum Go to 1.24, update x/net to v0.50.0`

- `go.mod`: `go 1.23.0` → `1.24.0`, `x/net` `v0.43.0` → `v0.50.0`;
  `x/text` indirect follows to `v0.34.0`.
- `.github/workflows/{build,test}.yml`: matrix
  `{1.23, 1.24, 1.25}` → `{1.24, 1.25, 1.26}`.
- `Makefile`: tier tool versions via `get_version.sh`:
  - golangci-lint: `v2.8.0` (Go 1.24) / `v2.11.4` (Go 1.25+)
  - revive: `v1.14.0` (Go 1.24) / `v1.15.0` (Go 1.25+)
- Docs (`AGENTS.md`, `BUILDING.md`, `README.md`,
  `internal/build/README-coverage.md`): reflect the new floor and
  tool versions; drop stale `go -C` / Go-1.X-generics notes that
  were inaccurate prior to this PR.

### 3. `build: enable modernize linter`

Enables `modernize` in `.golangci.yml` and applies the mechanical
rewrites it surfaces:

- counted `for i := 0; i < N; i++` loops migrate to range-over-int
  (`for i := range N`, or `for range N` when the index is unused);
- benchmark loops migrate to `for b.Loop()`, which subsumes the
  preceding `b.ResetTimer()` calls; the two `IIf` benchmarks that
  relied on the loop index keep an explicit counter to preserve the
  alternating-branch pattern;
- `var counter int64` with `atomic.AddInt64` / `atomic.LoadInt64`
  in `TestRunConcurrentTest` collapses to `var counter atomic.Int64`
  with `counter.Add` / `counter.Load`;
- unnecessary generic type arguments are dropped
  (`S[netip.Addr](…)` → `S(…)`, and the `SortedValuesUnlikelyCond`
  nil-map call only keeps the one non-inferable type parameter).

### 4. `docs(testing): tighten TestCase decision rule and anti-patterns`

Reorders `TESTING.md` so the decision rule (≥2 rows of shared-shape
data feeding one assertion path) appears before the structural
checklist, and spells out that the checklist is necessary but not
sufficient — passing it on a single-case `TestCase`, or on one whose
struct field holds the operation under test, still means the wrong
tool was picked. Two new entries in the forbidden-patterns list
cover those cases. `AGENTS.md` trades the bare "Table-driven tests
are preferred." line for one that names the ≥2-row threshold and
links to `TESTING.md`. Net +4 lines in `TESTING.md`; docs only.

### 5. `test: close coverage gaps in error, stack, and slice helpers`

Targeted coverage additions for branches that the existing suite
missed:

- nil-receiver paths (`WrappedError.Error`/`Unwrap`,
  `CompoundError.OK`, `ErrGroup.Err` on a pristine group);
- non-first branches of type switches in `Unwrap`,
  `CheckIsTemporary`, `CheckIsTimeout`, and `isSamePointer`;
- short-circuit and early-return paths in `SliceEqual`,
  `SliceEqualFn`, `SliceUniquify`, `SliceReplaceFn`;
- parser fall-throughs in `splitHostPortBracketed` and
  `SplitAddrPort`;
- panic paths in `writeFormat` (asserted by branch-specific
  substring), unknown-PC in `frameForPC`, and the skip-overflow
  branch of `StackFrame`;
- the `IsZero() bool` custom-interface branch, the typed-nil
  collapse branch of `AsError`, and type-mismatch skip in
  `ListForEach`/`ListForEachBackward`.

Tests only; no production code changes.

## Why v0.50.0 specifically

| `x/net` | go.mod `go` directive |
|---------|-----------------------|
| v0.43.0 (current) | 1.23.0 |
| v0.44.0 – **v0.50.0** | **1.24.0** |
| v0.51.0 – v0.53.0 | 1.25.0 |

Picking the top of the 1.24 band keeps us on the latest release that
does not force a further Go bump.

## Test plan

- [x] `make tidy` passes locally with the tiered lint tool pins on
  both the Go 1.24 and Go 1.25+ tiers.
- [x] `make test` passes locally.
- [x] `make` (full build cycle) passes locally.
- [ ] CI green on Go 1.24, 1.25, 1.26 (matrix).
- [ ] Codecov upload succeeds on the updated toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum Go requirement raised to 1.24; project module/tool pins updated and lint/tooling defaults bumped
  * Linter configuration extended (additional linter enabled)
  * CI build/test matrices and workflows updated to run Go 1.24, 1.25 and 1.26

* **Documentation**
  * Development, building and testing docs revised to reflect new Go/tooling and CI coverage

* **Tests**
  * Test and benchmark suites expanded and modernised for consistency and additional edge-case coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

