### PR TITLE
Build tooling: Claude workflows, markdownlint 120, get_version.sh docs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,33 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    if: |
+      github.actor != 'renovate[bot]' &&
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,42 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.actor == 'amery' || github.actor == 'karasz') &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ The build system includes automatic Markdown linting:
 
 - Detects markdownlint-cli via pnpx
 - Configuration in `internal/build/markdownlint.json`
-- 80-character line limits and strict formatting rules
+- 80-character prose line limit (120 in code blocks), strict formatting rules
 - Selective HTML allowlist (comments, br, kbd, etc.)
 - Runs automatically with `make fmt` when available
 
@@ -299,9 +299,7 @@ To automatically fix field alignment issues across the codebase:
 
 ```bash
 # Run the fieldalignment tool with automatic fixes
-GOXTOOLS="golang.org/x/tools/go/analysis/passes"
-FA="$GOXTOOLS/fieldalignment/cmd/fieldalignment"
-go run "$FA@latest" -fix ./...
+go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest -fix ./...
 ```
 
 This tool will:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -120,6 +120,20 @@ Selects appropriate tool versions based on Go version:
 - Supports version progression (newer Go = newer tools).
 - Graceful fallback for unknown versions.
 
+**Beyond tool versions:** the script takes a Go-version baseline
+and an ordered list of arbitrary string values, returning the
+one matching the current Go (or the last, for newer Go). The
+values don't have to be version strings — any per-tier value
+works, so the same picker can select per-tier config files when
+a rule set diverges across tool releases. Binary and config then
+move in lock-step per Go tier:
+
+```make
+REVIVE_VERSION   ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 v1.14.0 v1.15.0)
+REVIVE_CONF_FILE ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 revive-v1.14.toml revive.toml)
+REVIVE_CONF      ?= $(TOOLSDIR)/$(REVIVE_CONF_FILE)
+```
+
 ### Coverage System (`make_coverage.sh`)
 
 Enhanced coverage testing for individual modules:
@@ -460,6 +474,9 @@ Each project can customise:
 
 - **`internal/build/cspell.json`**: Project-specific dictionary.
 - **`internal/build/revive.toml`**: Additional linting rules.
+  May be paired with per-tier variants (e.g.
+  `revive-v1.14.toml`) when rules differ across revive releases;
+  `get_version.sh` picks the right one.
 - **`internal/build/markdownlint.json`**: Markdown style rules.
 - **`internal/build/languagetool.cfg`**: Grammar checking rules.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -856,8 +856,7 @@ type testCase struct {
 Use the field alignment tool to verify:
 
 ```bash
-go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/\
- fieldalignment@latest -fix ./...
+go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest -fix ./...
 ```
 
 ## Concurrent Testing
@@ -978,8 +977,7 @@ Tests should maintain high coverage. Use with CI:
 make test GOTEST_FLAGS="-coverprofile=coverage.out"
 
 # Check coverage threshold
-go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | \
-  sed 's/%//' | awk '{if($1<80) exit 1}'
+go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//' | awk '{if($1<80) exit 1}'
 ```
 
 ### Test Tags

--- a/internal/build/markdownlint.json
+++ b/internal/build/markdownlint.json
@@ -4,7 +4,7 @@
   "MD013": {
     "line_length": 80,
     "heading_line_length": 80,
-    "code_block_line_length": 80,
+    "code_block_line_length": 120,
     "code_blocks": true,
     "tables": false,
     "headings": true,


### PR DESCRIPTION
## Summary

- Add Claude Code GitHub workflows (`claude.yml`,
  `claude-code-review.yml`) mirroring kagal. `@claude` mentions are
  gated to `amery` / `karasz`; auto-review runs on non-draft PRs
  (Renovate excluded) via the `code-review` plugin. Relies on the
  Claude Code GitHub App being installed and `CLAUDE_CODE_OAUTH_TOKEN`
  configured; workflow permissions stay read-only.
- Raise markdownlint `code_block_line_length` from 80 to 120 (prose
  still 80). Unwrap the coverage-threshold pipeline and fieldalignment
  snippets in `TESTING.md` / `AGENTS.md` that existed only to dodge
  the old ceiling. Update line-length guidance in `AGENTS.md` to
  reflect the prose/code split.
- Document `get_version.sh` as a tier-aware picker for arbitrary
  strings, not just tool versions. Add a `REVIVE_CONF_FILE` example
  showing how the same mechanism can select per-tier revive configs
  when a rule set diverges across releases, with a follow-up note in
  the Configuration Customisation section.

## Test plan

- [x] `make` passes at HEAD.
- [ ] Verify Claude Code workflows trigger correctly after merge:
      `@claude` mention in a test issue, auto-review on a test PR.
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` is available at the org or
      repo level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code-review and assistant-trigger workflows for pull requests, reviews and issue comments
* **Documentation**
  * Clarified build/version selection examples and pairing of per-tier config variants
  * Relaxed prose/code-block line limits and adjusted markdown linting guidance to allow 120-character code lines
  * Simplified Go command examples in testing and build docs to use single-line invocations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->