### PR TITLE
build: force `make test` to bypass the Go test cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ go tool cover -html=coverage.out
 
 1. The Makefile defines `GOTEST_FLAGS ?=` (empty by default).
 2. The generated rules in `.tmp/gen.mk` use it in the test target:
-   `$(GO) test $(GOTEST_FLAGS) ./...`.
+   `$(GO) test -count=1 $(GOTEST_FLAGS) ./...`.
 3. Any flags passed via `GOTEST_FLAGS` are forwarded directly to `go test`.
 
 This provides a clean interface for passing arbitrary test flags without

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -107,7 +107,7 @@ Creates Makefile rules for each discovered module:
 - `coverage` - Run tests with coverage collection
 - `get` - Download module dependencies
 - `race` - Run tests with race detection (CGO_ENABLED=1)
-- `test` - Run unit tests
+- `test` - Run unit tests (no cache reuse)
 - `tidy` - Format, lint, and validate code
 - `up` - Update module dependencies
 
@@ -326,7 +326,9 @@ GitHub Actions workflows provide:
 
 ### Test Execution Options
 
-The `GOTEST_FLAGS` variable allows flexible test execution:
+The generated `test` rule runs
+`$(GO) test -count=1 $(GOTEST_FLAGS) ./...`; any flags you pass via
+`GOTEST_FLAGS` are appended:
 
 ```bash
 # Run with race detection via dedicated target

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -134,7 +134,7 @@ gen_make_targets() {
 \$(GO) mod tidy"
 		;;
 	test)
-		call="\$(GO) $cmd \$(GOTEST_FLAGS) ./..."
+		call="\$(GO) test -count=1 \$(GOTEST_FLAGS) ./..."
 		;;
 	coverage)
 		call="\$(TOOLSDIR)/make_coverage.sh \"$name\" \".\" \"\$(COVERAGE_DIR)\""


### PR DESCRIPTION
## Summary

- Add `-count=1` to the generated `test` rule in
  `internal/build/gen_mk.sh` so `make test` re-runs instead of
  returning cached results. Matches what `race` already did.
- AGENTS.md `How It Works` snippet now shows the new rule literal.
- BUILDING.md labels `test` as no-cache-reuse in the
  generated-commands list and reproduces the literal rule alongside
  the `GOTEST_FLAGS` examples. BUILDING.md is the shared reference
  for sibling darvaza.org repos, so the explanation lives there.

## Rationale

`test` is deliberately outside `make all` (`get generate tidy build`).
An explicit `make test` is asking the tests to actually run — cached
PASS results defeat the point.

## Test plan

- [ ] `make test` succeeds.
- [ ] `make test` run twice in a row re-executes both times (no
      `(cached)` annotations in `go test` output).
- [ ] Generated `.tmp/gen.mk` shows `go test -count=1` in every
      per-module `test-*` rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified unit test execution behaviour with cache disabled.
  * Updated test configuration guidance.

* **Chores**
  * Modified test target generation to enforce cache-free test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darvaza-proxy/core/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->