### PR TITLE
docs: refactor AGENTS.md / BUILDING.md split, fix factual errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,15 @@ repository. For developers and general project information, please refer to
 
 ## Related Documentation
 
-- [README.md](README.md) - Package overview and API reference
-- [TESTING.md](TESTING.md) - Testing patterns and guidelines for all
-  darvaza.org projects
-- [TESTING_core.md](TESTING_core.md) - Core-specific testing patterns
+- [README.md](README.md) — Package overview and API reference.
+- [BUILDING.md](BUILDING.md) — Shared build-system reference for all
+  darvaza.org projects (make targets, tooling, linting, CI, pre-commit
+  workflow, troubleshooting).
+- [internal/build/README-coverage.md](internal/build/README-coverage.md) —
+  Coverage system documentation.
+- [TESTING.md](TESTING.md) — Testing patterns and guidelines for all
+  darvaza.org projects.
+- [TESTING_core.md](TESTING_core.md) — Core-specific testing patterns.
 
 ## Repository Overview
 
@@ -20,416 +25,78 @@ It serves as the base for other darvaza.org projects.
 
 ## Prerequisites
 
-Before starting development, ensure you have:
+- Go 1.24 or later (the project's minimum).
+- `make` available; `$GOPATH` configured.
 
-- Go 1.24 or later installed (check with `go version`).
-- `make` command available (usually pre-installed on Unix systems).
-- `$GOPATH` configured correctly (typically `~/go`).
-- Git configured for proper line endings.
-
-## Common Development Commands
-
-```bash
-# Full build cycle (get deps, generate, tidy, build)
-make all
-
-# Run tests
-make test
-
-# Run tests with coverage
-make test GOTEST_FLAGS="-cover"
-
-# Run tests with verbose output and coverage
-make test GOTEST_FLAGS="-v -cover"
-
-# Build test binaries without running (useful for debugging)
-make test GOTEST_FLAGS="-c"
-
-# Generate coverage reports
-make coverage
-
-# Generate Codecov configuration and upload scripts
-make codecov
-
-# Format code and tidy dependencies (run before committing)
-make tidy
-
-# Clean build artifacts
-make clean
-
-# Update dependencies
-make up
-
-# Run go:generate directives
-make generate
-```
-
-## Build System Features
-
-### Whitespace and EOF Handling
-
-The `internal/build/fix_whitespace.sh` script automatically:
-
-- Removes trailing whitespace from all text files
-- Ensures files end with a newline
-- Excludes binary files and version control directories
-- Integrates with `make fmt` for non-Go files
-- Supports both directory scanning and explicit file arguments
-
-### Markdownlint Integration
-
-The build system includes automatic Markdown linting:
-
-- Detects markdownlint-cli via pnpx
-- Configuration in `internal/build/markdownlint.json`
-- 80-character prose line limit (120 in code blocks), strict formatting rules
-- Selective HTML allowlist (comments, br, kbd, etc.)
-- Runs automatically with `make fmt` when available
-
-### LanguageTool Integration
-
-Grammar and style checking for Markdown files:
-
-- Detects LanguageTool via pnpx.
-- British English configuration in `internal/build/languagetool.cfg`.
-- Available via `make check-grammar` target.
-- Not integrated into `make tidy` due to false positives.
-- Checks for missing articles, punctuation, and proper hyphenation.
-
-### CSpell Integration
-
-Spell checking for both Markdown and Go source files:
-
-- Detects cspell via pnpx
-- British English configuration in `internal/build/cspell.json`
-- New `check-spelling` target
-- Integrated into `make tidy`
-- Custom word list for project-specific terminology
-- Checks both documentation and code comments
-
-### Coverage Collection
-
-The build system includes automated coverage report generation:
-
-- `make coverage` target runs tests with coverage flags
-- `internal/build/make_coverage.sh` handles test execution
-- Generates coverage reports in multiple formats (text, HTML)
-- Coverage artifacts stored in `.tmp/coverage/` directory
-- Integrated with CI/CD workflows for automated reporting
-
-### Codecov Integration
-
-Enhanced coverage reporting with monorepo support:
-
-- `make codecov` target generates Codecov configuration
-- `internal/build/make_codecov.sh` creates:
-  - `codecov.yml`: Dynamic configuration with per-module flags
-  - `codecov.sh`: Upload script for bulk submission
-- Module-specific coverage targets (80% default)
-- Path mappings for accurate coverage attribution
-- GitHub Actions workflow automatically uploads coverage data
-- PR comments show coverage changes per module
-- See [internal/build/README-coverage.md](internal/build/README-coverage.md)
-  for details
+See [BUILDING.md → Required Tools](BUILDING.md#required-tools) for the
+full toolchain.
 
 ## Code Architecture
 
 ### Key Design Principles
 
-- **Zero dependencies**: Only the Go standard library and minimal golang.org/x
-  packages.
-- **Generic programming**: Extensive use of Go generics for type-safe
+- **Zero dependencies**: only the Go standard library and minimal
+  `golang.org/x` packages.
+- **Generic programming**: extensive use of Go generics for type-safe
   utilities.
-- **Single package**: Everything is in the `core` package, no subpackages.
+- **Single package**: everything is in the `core` package; no subpackages.
 
 ### Major Components
 
-- **Error handling** (errors.go, panicerror.go, compounderror.go): Advanced
-  error wrapping with stack traces, panic recovery, and compound errors.
-- **Context utilities** (context.go): Type-safe context keys with
+- **Error handling** (`errors.go`, `panicerror.go`, `compounderror.go`):
+  advanced error wrapping with stack traces, panic recovery, and compound
+  errors.
+- **Context utilities** (`context.go`): type-safe context keys with
   `ContextKey[T]`.
-- **Network utilities** (addrs.go, addrport.go, splithostport.go): Address
-  parsing, interface enumeration.
-- **Generic collections** (slices.go, lists.go, maps.go): Functional
+- **Network utilities** (`addrs.go`, `addrport.go`, `splithostport.go`):
+  address parsing, interface enumeration.
+- **Generic collections** (`slices.go`, `lists.go`, `maps.go`): functional
   programming patterns for collections.
-- **Synchronization** (sync.go): Advanced synchronization primitives.
+- **Synchronisation** (`sync.go`): advanced synchronisation primitives.
 
-### Code Quality Standards
-
-The project enforces strict linting rules via revive (configuration in
-`internal/build/revive.toml`):
-
-- Max function length: 40 lines.
-- Max function results: 3.
-- Max arguments: 5.
-- Cognitive complexity: 7.
-- Cyclomatic complexity: 10.
-
-Always run `make tidy` before committing to ensure proper formatting.
-
-### Testing Patterns
+## Testing
 
 - Table-driven tests via `TestCase` apply when ≥2 rows of shared-shape
   data feed one assertion path; otherwise write plain test functions.
   See [TESTING.md](./TESTING.md) for the full decision rule.
 - All testing utilities are public in `testing.go` for external use.
 - Comprehensive coverage for generic functions is expected.
-- Testing utilities log successful assertions for better debugging.
+- Core-specific testing patterns and self-testing approaches are in
+  [TESTING_core.md](./TESTING_core.md).
+- Test execution flags and the generated `test` rule are documented in
+  [BUILDING.md → Test Execution Options](BUILDING.md#test-execution-options).
 
-**Development Testing Guidelines:**
+## Build & Tooling Reference
 
-For comprehensive testing patterns and assertion function usage, see:
+This repo uses the shared darvaza.org build system. Most-used commands:
 
-- [TESTING.md](./TESTING.md) - General testing patterns for all darvaza.org
-  projects
-- [TESTING_core.md](./TESTING_core.md) - Core-specific testing patterns and
-  self-testing approaches
+```bash
+make all          # full build cycle (get, generate, tidy, build)
+make tidy         # format, lint, validate
+make test         # run tests (no cache reuse)
+make coverage     # tests with coverage
+```
+
+Full reference in [BUILDING.md](BUILDING.md). Key sections:
+
+- [Build Targets](BUILDING.md#build-targets) — primary and per-module
+  targets.
+- [Test Execution Options](BUILDING.md#test-execution-options) —
+  `GOTEST_FLAGS` semantics; the generated `test` rule passes `-count=1`.
+- [Code Quality Standards](BUILDING.md#code-quality-standards) — revive
+  linting limits (function length, complexity, argument counts).
+- [Field Alignment](BUILDING.md#field-alignment) — safe `fieldalignment`
+  workflow via probe file.
+- [golangci-lint Configuration](BUILDING.md#golangci-lint-configuration).
+- [Documentation Standards](BUILDING.md#documentation-standards) —
+  LanguageTool, CSpell, Markdownlint conventions and common issues.
+- [Pre-commit Checklist](BUILDING.md#pre-commit-checklist).
+- [CI/CD Integration](BUILDING.md#cicd-integration) including DeepSource
+  configuration.
+- [Troubleshooting](BUILDING.md#troubleshooting).
 
 ## Important Notes
 
-- Go 1.24 is the minimum required version.
-- The Makefile dynamically generates rules for subprojects.
-- Tool versions (golangci-lint, revive) are selected based on Go version.
-- This is a utility library - no business logic, only reusable helpers.
-- Always use `pnpm` instead of `npm` for any JavaScript/TypeScript tooling.
-
-## Testing with GOTEST_FLAGS
-
-The `GOTEST_FLAGS` environment variable allows flexible test execution by
-passing additional flags to `go test`. This variable is defined in the
-Makefile (line 10) with an empty default value and is used when running tests
-through the generated rules in `.tmp/gen.mk:39`.
-
-### Common Usage Examples
-
-```bash
-# Run tests with race detection
-make test GOTEST_FLAGS="-race"
-
-# Run specific tests by pattern
-make test GOTEST_FLAGS="-run TestSpecific"
-
-# Generate coverage profile (alternative to 'make coverage')
-make test GOTEST_FLAGS="-coverprofile=coverage.out"
-
-# Run tests with timeout
-make test GOTEST_FLAGS="-timeout 30s"
-
-# Combine multiple flags
-make test GOTEST_FLAGS="-v -race -coverprofile=coverage.out"
-
-# Run benchmarks
-make test GOTEST_FLAGS="-bench=. -benchmem"
-
-# Skip long-running tests
-make test GOTEST_FLAGS="-short"
-
-# Test with specific CPU count
-make test GOTEST_FLAGS="-cpu=1,2,4"
-```
-
-### Integration with Coverage
-
-While `make coverage` provides automated coverage collection across all
-modules, you can use `GOTEST_FLAGS` for more targeted coverage analysis:
-
-```bash
-# Coverage for specific package with detailed output
-make test GOTEST_FLAGS="-v -coverprofile=coverage.out -covermode=atomic"
-
-# Coverage with HTML output
-make test GOTEST_FLAGS="-coverprofile=coverage.out"
-go tool cover -html=coverage.out
-```
-
-### How It Works
-
-1. The Makefile defines `GOTEST_FLAGS ?=` (empty by default).
-2. The generated rules in `.tmp/gen.mk` use it in the test target:
-   `$(GO) test -count=1 $(GOTEST_FLAGS) ./...`.
-3. Any flags passed via `GOTEST_FLAGS` are forwarded directly to `go test`.
-
-This provides a clean interface for passing arbitrary test flags without
-modifying the Makefile, making it easy to run tests with different
-configurations for debugging, coverage analysis, or CI/CD pipelines.
-
-## CI/CD and Code Analysis
-
-### DeepSource Configuration
-
-The project uses DeepSource for static code analysis. Configuration is in the
-`.deepsource.toml` file:
-
-- Shell analyser is configured for POSIX sh dialect.
-- To ignore specific issues for certain files, use `[[issues]]` blocks with
-  `paths` (not `exclude_patterns`).
-- Common shell issues:
-  - SH-1091: "local is undefined in POSIX sh" - excluded for all .sh files.
-  - SH-2013: "Use while read for reading lines" - disable with
-    ShellCheck directive comment.
-
-### GitHub Actions
-
-- **Codecov workflow**: Automatically runs on push/PR to generate coverage
-  reports.
-- **Make workflow**: Tests across Go versions 1.24, 1.25 and 1.26.
-- All CI checks must pass before merging PRs.
-
-### Working with Build Tools
-
-When LanguageTool reports issues:
-
-- Custom dictionary is auto-generated from CSpell words in
-  `.tmp/languagetool-dict.txt`.
-- Technical terms should be added to `internal/build/cspell.json`.
-- False positives for code-related punctuation are disabled in
-  `languagetool.cfg`.
-
-## Linting and Code Quality
-
-### Field Alignment
-
-`fieldalignment` orders struct fields for minimum padding. Running
-`-fix` against the source tree is unsafe — it strips every comment
-from every file it touches. Use an isolated probe instead:
-
-1. Copy the structs you want to optimise into `.tmp/fieldalign.go`
-   as `package probe`. Comments are expendable in the probe.
-2. Run the tool against just the probe file:
-
-   ```bash
-   go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest -fix .tmp/fieldalign.go
-   ```
-
-3. Diff the rewritten probe against your copies to read off the
-   suggested field order.
-4. Apply the new order to the real source by hand, preserving all
-   comments and doc strings.
-5. Delete the probe. Run `make tidy`.
-
-Reordering may require updating struct literal initialisations
-elsewhere in the tree. CI enforces alignment via `govet.fieldalignment`
-in `.golangci.yml`.
-
-### golangci-lint Configuration
-
-The project uses golangci-lint for comprehensive Go code linting.
-Configuration is stored in `.golangci.yml` in the project root.
-
-#### Current Configuration Status
-
-The project uses golangci-lint v2.8.0 (Go 1.24) and v2.11.4 (Go 1.25+).
-The current `.golangci.yml` uses the v2 format:
-
-- ✅ **Functionally works**: All linters and settings are properly applied.
-- ✅ **Field alignment enabled**: `govet: enable: [fieldalignment]` works.
-- ✅ **Schema validation**: Uses proper v2 format with `version: "2"`.
-
-#### Configuration Features
-
-The v2 configuration provides:
-
-- Improved schema validation with proper IDE support.
-- Separate formatters section for gofmt and goimports.
-- Built-in exclusion presets for common false positives.
-- Enhanced exclusion patterns for generated code.
-
-#### Field Alignment Integration
-
-- Always run `make tidy` which includes golangci-lint checks
-- Field alignment linter is properly configured and working
-- Schema format doesn't affect linting functionality, only IDE validation
-- Technical linter names are added to `internal/build/cspell.json`
-
-### Documentation Standards
-
-When editing Markdown files, ensure compliance with:
-
-- **LanguageTool**: Optionally check for missing articles ("a", "an", "the"),
-  punctuation, and proper hyphenation of compound modifiers via
-  `make check-grammar`.
-- **CSpell**: Check spelling in both documentation and code comments.
-- **Markdownlint**: Follow standard Markdown formatting rules.
-
-### Common Documentation Issues to Check
-
-1. **Missing Articles**: Ensure proper use of "a", "an", and "the".
-   - ❌ "converts value using provided function".
-   - ✅ "converts value using a provided function".
-
-2. **Missing Punctuation**: End all list items consistently.
-   - ❌ "Comprehensive coverage for generic functions is expected".
-   - ✅ "Comprehensive coverage for generic functions is expected.".
-
-3. **Compound Modifiers**: Hyphenate when used as modifiers.
-   - ❌ "capture specific stack frame".
-   - ✅ "capture-specific stack frame".
-
-### Writing Documentation Guidelines
-
-When creating or editing documentation files:
-
-1. **File Structure**:
-   - Always include a link to related documentation (e.g., AGENTS.md should
-     link to README.md).
-   - Add prerequisites or setup instructions before diving into commands.
-   - Include paths to configuration files when mentioning tools (e.g.,
-     revive.toml).
-
-2. **Formatting Consistency**:
-   - End all bullet points with periods for consistency.
-   - Capitalize proper nouns correctly (JavaScript, TypeScript, Markdown).
-   - Use consistent punctuation in examples and lists.
-
-3. **Clarity and Context**:
-   - Provide context for AI agents and developers alike.
-   - Include "why" explanations, not just "what" descriptions.
-   - Add examples for complex concepts or common pitfalls.
-
-4. **Maintenance**:
-   - Update documentation when adding new tools or changing workflows.
-   - Keep the pre-commit checklist current with project practices.
-   - Review documentation changes for the issues listed above.
-
-### Pre-commit Checklist
-
-1. **ALWAYS run `make tidy` first** - Fix ALL issues before committing:
-   - Go code formatting and whitespace clean-up
-   - Markdown files checked with CSpell and markdownlint
-   - Shell scripts checked with shellcheck
-   - If `make tidy` fails, fix the issues and run it again until it passes
-2. Verify all tests pass with `make test`.
-3. Ensure no linting violations remain.
-4. Update `AGENTS.md` to reflect any changes in development workflow or
-   standards.
-5. Update `README.md` to reflect significant changes in functionality or API.
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-1. **LanguageTool false positives**:
-   - Add technical terms to `internal/build/cspell.json`.
-   - Dictionary will auto-regenerate on next `make check-grammar`.
-   - For persistent issues, consider adding rules to `languagetool.cfg`.
-
-2. **DeepSource shell issues**:
-   - Use ShellCheck disable comments for specific lines.
-   - Update `.deepsource.toml` with issue-specific `paths` configurations.
-   - Remember: DeepSource uses `paths`, not `exclude_patterns` in
-     `[[issues]]` blocks.
-
-3. **Coverage collection failures**:
-   - Ensure `.tmp/index` exists by running `make .tmp/index`.
-   - Check that all modules have test files.
-   - Use `GOTEST_FLAGS` to pass additional flags to tests.
-
-4. **Linting tool detection**:
-   - Tools are auto-detected via `pnpx`.
-   - If tools aren't found, they're replaced with `true` (no-op).
-   - Install tools globally with `pnpm install -g <tool>` if needed.
-
-5. **golangci-lint configuration**:
-   - Configuration uses v2.8.0+ with proper v2 format.
-   - System uses pinned version via Makefile `GOLANGCI_LINT_VERSION`.
-   - Technical linter names are added to `internal/build/cspell.json`.
+- This is a utility library — no business logic, only reusable helpers.
+- The zero-dependency discipline is load-bearing; do not introduce
+  external imports beyond the standard library and minimal `golang.org/x`.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,8 +26,6 @@ The build system consists of these key elements:
 4. **GitHub Workflows** (`/.github/workflows/`) - CI/CD automation.
 5. **Dynamic Rule Generation** - Module discovery and Makefile rule creation.
 6. **Temporary Directory** (`.tmp/`) - Generated files and build artefacts.
-7. **VS Code Integration** (`.vscode/`) - Editor configuration with symlinks
-   to shared settings.
 
 ### Design Philosophy
 
@@ -55,9 +53,6 @@ project-root/
 │   ├── race.yml              # Race detection testing
 │   ├── codecov.yml           # Coverage reporting
 │   └── renovate.yml          # Dependency updates
-├── .vscode/                   # VS Code configuration
-│   ├── settings.json         # Editor settings
-│   └── cspell.json           # Symlink to internal/build/cspell.json
 ├── .tmp/                      # Generated files (gitignored)
 │   ├── index                 # Module discovery index
 │   ├── gen.mk                # Generated Makefile rules
@@ -136,13 +131,12 @@ REVIVE_CONF      ?= $(TOOLSDIR)/$(REVIVE_CONF_FILE)
 
 ### Coverage System (`make_coverage.sh`)
 
-Enhanced coverage testing for individual modules:
+Coverage testing for individual modules:
 
 - Tests single module with `-covermode=atomic` for atomic coverage.
-- Generates multiple output formats (.prof, .func, .html, .stdout).
-- Improved error formatting with dedicated format function.
-- Better failure reporting with filtered test output.
+- Generates multiple output formats (`.prof`, `.func`, `.html`, `.stdout`).
 - Uses `go -C` for proper directory handling.
+- Filtered test output on failure.
 
 ### Coverage Merge Utility (`merge_coverage.sh`)
 
@@ -155,13 +149,12 @@ Standalone utility for merging coverage profiles:
 
 ### Codecov Integration (`make_codecov.sh`)
 
-Simplified Codecov integration for monorepo coverage:
+Codecov integration for monorepo coverage:
 
-- Generates only upload script (no complex codecov.yml).
-- Uses separate calls per module with proper flags.
-- Removes `--codecov-yml-path` dependency.
+- Generates the upload script (no `codecov.yml`).
+- One call per module with module-specific flags.
 - Relies on Codecov's automatic configuration detection.
-- Simplified file naming (`coverage_${name}.prof`).
+- File naming: `coverage_${name}.prof`.
 
 ## Temporary Directory (`.tmp/`)
 
@@ -185,27 +178,6 @@ The `.tmp/` directory is excluded from version control via `.gitignore`:
 
 This prevents build artefacts from being committed whilst allowing the build
 system to cache generated files locally.
-
-## VS Code Integration
-
-### Configuration Sharing
-
-The build system provides VS Code integration through `.vscode/` directories:
-
-- **`settings.json`**: Editor-specific settings for each project.
-- **`cspell.json`**: Symlinked to `internal/build/cspell.json` for consistent
-  spell checking.
-
-### Symlink Structure
-
-The cspell configuration is shared via symbolic links:
-
-```bash
-.vscode/cspell.json -> ../internal/build/cspell.json
-```
-
-This ensures VS Code uses the same spell checking dictionary as the build
-system, maintaining consistency between editor and CI environments.
 
 ## Configuration Files
 
@@ -235,9 +207,9 @@ indent_size = 2
 trim_trailing_whitespace = false
 ```
 
-### Go Linting (`.golangci.yml`)
+### golangci-lint Configuration
 
-Comprehensive Go code analysis:
+Comprehensive Go code analysis via `.golangci.yml`:
 
 - Uses golangci-lint v2.8.0+ with v2 configuration format.
 - Enables 15+ linters including `fieldalignment`, `revive`, `staticcheck`.
@@ -296,7 +268,7 @@ Tools are auto-detected and replaced with `true` (no-op) if unavailable.
 
 #### Required Tools
 
-- **Go 1.24+**: Required minimum (bumped for golang.org/x/net v0.50.0).
+- **Go 1.24+**: Required minimum.
 - **golangci-lint**: Go code linting (version selected by Go version).
 - **revive**: Additional Go linting rules.
 - **make**: Build orchestration.
@@ -364,11 +336,83 @@ Strict code quality enforcement:
 
 ### Additional Quality Tools
 
-- **Field Alignment**: Struct optimisation for memory efficiency.
+- **Field Alignment**: Struct optimisation for memory efficiency
+  (see [Field Alignment](#field-alignment) for the safe workflow).
 - **Race Detection**: Comprehensive race condition testing with CGO enabled.
 - **Spell Checking**: Documentation and code comments.
 - **Grammar Checking**: Markdown documentation.
 - **Whitespace Normalisation**: Consistent file formatting.
+
+### Field Alignment
+
+`fieldalignment` orders struct fields for minimum padding. Running
+`-fix` against the source tree is unsafe — it strips every comment
+from every file it touches. Use an isolated probe instead:
+
+1. Copy the structs you want to optimise into `.tmp/fieldalign.go`
+   as `package probe`. Comments are expendable in the probe.
+2. Run the tool against just the probe file:
+
+   ```bash
+   go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest -fix .tmp/fieldalign.go
+   ```
+
+3. Diff the rewritten probe against your copies to read off the
+   suggested field order.
+4. Apply the new order to the real source by hand, preserving all
+   comments and doc strings.
+5. Delete the probe. Run `make tidy`.
+
+Reordering may require updating struct literal initialisations
+elsewhere in the tree. CI enforces alignment via `govet.fieldalignment`
+in `.golangci.yml`.
+
+## Documentation Standards
+
+Markdown documentation across darvaza.org projects is checked by three
+tools, all auto-detected (see
+[Optional Tool Detection](#optional-tool-detection)):
+
+- **LanguageTool**: grammar and style. British English configuration in
+  `internal/build/languagetool.cfg`. Run via `make check-grammar` —
+  not integrated into `make tidy` due to false positives. Custom
+  dictionary is auto-generated from CSpell words in
+  `.tmp/languagetool-dict.txt`.
+- **CSpell**: spell checking for both `.md` and `.go` files. British
+  English with project terminology in `internal/build/cspell.json`.
+  Runs as part of `make tidy`.
+- **markdownlint**: Markdown formatting. Configuration in
+  `internal/build/markdownlint.json` — 80-character prose line limit
+  (120 inside code blocks), strict formatting rules, selective HTML
+  allowlist. Runs automatically as part of `make tidy` when available.
+
+### Common Documentation Issues
+
+1. **Missing articles**: ensure proper use of "a", "an", "the".
+   - ❌ "converts value using provided function"
+   - ✅ "converts a value using a provided function"
+2. **Missing punctuation**: end all list items consistently.
+   - ❌ "Comprehensive coverage for generic functions is expected"
+   - ✅ "Comprehensive coverage for generic functions is expected."
+3. **Compound modifiers**: hyphenate when used as modifiers.
+   - ❌ "capture specific stack frame"
+   - ✅ "capture-specific stack frame"
+
+### Writing Documentation Guidelines
+
+1. **File structure**:
+   - Link to related documentation (e.g. an agent guide should link to
+     `README.md`).
+   - Include paths to configuration files when mentioning tools.
+2. **Formatting consistency**:
+   - End all bullet points with periods.
+   - Capitalise proper nouns correctly (JavaScript, TypeScript, Markdown).
+3. **Clarity and context**:
+   - Provide context for AI agents and developers alike.
+   - Include "why" explanations, not just "what" descriptions.
+4. **Maintenance**:
+   - Update documentation when adding new tools or changing workflows.
+   - Keep any pre-commit checklist current with project practices.
 
 ## Monorepo Features
 
@@ -491,7 +535,6 @@ The build system integrates with development environments:
 - **EditorConfig**: Automatic formatting in IDEs.
 - **golangci-lint**: VS Code and GoLand integration.
 - **Coverage Reports**: IDE coverage display.
-- **VS Code Settings**: Shared configuration via symlinks.
 
 ### CI/CD Platforms
 
@@ -506,16 +549,31 @@ GitHub Actions workflows provide:
 
 - **Codecov**: Coverage tracking and PR comments.
 - **Renovate**: Automated dependency updates.
-- **DeepSource**: Additional static analysis (where configured).
+- **DeepSource**: Additional static analysis (where configured) — see
+  [DeepSource Configuration](#deepsource-configuration).
+
+### DeepSource Configuration
+
+When DeepSource static analysis is configured (`.deepsource.toml`):
+
+- Shell analyser typically set to POSIX sh dialect.
+- To ignore specific issues for certain files, use `[[issues]]` blocks
+  with `paths` (not `exclude_patterns`).
+- Common shell findings:
+  - **SH-1091**: "local is undefined in POSIX sh" — usually excluded
+    for all `.sh` files.
+  - **SH-2013**: "Use while read for reading lines" — disable per-line
+    with a ShellCheck directive comment.
 
 ## Best Practices
 
-### Workflow
+### Pre-commit Checklist
 
-1. **Always run `make tidy`** before committing.
-2. **Use `GOTEST_FLAGS`** for flexible test execution.
-3. **Generate coverage reports** for comprehensive testing.
-4. **Check spell and grammar** for documentation changes.
+1. Run `make tidy` until it passes. If it fails, fix the reported
+   issues and re-run.
+2. Verify tests pass with `make test`.
+3. Update the project's agent guide and `README.md` if dev workflow,
+   behaviour, or API changed.
 
 ### Project Setup
 
@@ -523,7 +581,6 @@ GitHub Actions workflows provide:
 2. **Customise `internal/build/`** configurations as needed.
 3. **Set up GitHub workflows** for CI/CD.
 4. **Configure Codecov tokens** for coverage reporting.
-5. **Create VS Code symlinks** for consistent editor experience.
 
 ### Monorepo Management
 
@@ -531,6 +588,41 @@ GitHub Actions workflows provide:
 2. **Use module replacement** for local dependencies.
 3. **Test modules individually** and collectively.
 4. **Monitor coverage per module** for better visibility.
+
+## Troubleshooting
+
+### LanguageTool false positives
+
+- Add technical terms to `internal/build/cspell.json`.
+- The dictionary auto-regenerates on the next `make check-grammar`.
+- For persistent issues, add rules to
+  `internal/build/languagetool.cfg`.
+
+### DeepSource shell issues
+
+- Use ShellCheck disable comments for specific lines.
+- Update `.deepsource.toml` with issue-specific `paths` configurations.
+- DeepSource uses `paths`, not `exclude_patterns`, in `[[issues]]`
+  blocks.
+
+### Coverage collection failures
+
+- Ensure `.tmp/index` exists by running `make .tmp/index`.
+- Check that all modules have test files.
+- Use `GOTEST_FLAGS` to pass additional flags to tests.
+
+### Linting tool not detected
+
+- Tools are auto-detected via `pnpm dlx`.
+- If a tool isn't found, it is replaced with `true` (no-op).
+- Install missing tools globally with `pnpm install -g <tool>` if
+  needed.
+
+### golangci-lint configuration
+
+- Configuration uses v2.8.0+ with the v2 format.
+- System uses a pinned version via Makefile `GOLANGCI_LINT_VERSION`.
+- Technical linter names are added to `internal/build/cspell.json`.
 
 This build system provides a robust foundation for Go projects of any size,
 from single packages to complex monorepos, whilst maintaining consistency and

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -52,7 +52,9 @@ project-root/
 │   ├── test.yml              # Testing (optional)
 │   ├── race.yml              # Race detection testing
 │   ├── codecov.yml           # Coverage reporting
-│   └── renovate.yml          # Dependency updates
+│   ├── renovate.yml          # Dependency updates
+│   ├── claude.yml            # Claude Code workflow
+│   └── claude-code-review.yml # Claude PR review workflow
 ├── .tmp/                      # Generated files (gitignored)
 │   ├── index                 # Module discovery index
 │   ├── gen.mk                # Generated Makefile rules
@@ -65,6 +67,7 @@ project-root/
     ├── make_coverage.sh      # Coverage collection
     ├── make_codecov.sh       # Codecov integration
     ├── fix_whitespace.sh     # Whitespace normalisation
+    ├── merge_coverage.sh     # Coverage profile merging
     ├── cspell.json           # Spell checking configuration
     ├── markdownlint.json     # Markdown linting configuration
     ├── languagetool.cfg      # Grammar checking configuration
@@ -186,6 +189,8 @@ system to cache generated files locally.
 Standardises code formatting across editors:
 
 ```ini
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
@@ -193,18 +198,17 @@ indent_style = tab
 indent_size = 8
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 80
 
 [*.go]
 indent_size = 4
 
-[*.{json,yaml,yml,js,ts}]
+[*.{json,yaml,yml,md}]
 indent_style = space
 indent_size = 2
 
-[*.md]
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = false
+[{go.mod,go.sum}]
+max_line_length = off
 ```
 
 ### golangci-lint Configuration

--- a/internal/build/README-coverage.md
+++ b/internal/build/README-coverage.md
@@ -13,7 +13,7 @@ The coverage system generates two types of coverage data:
 
 ## Prerequisites
 
-- Go 1.23 or later.
+- Go 1.24 or later.
 - A monorepo with modules defined in an index file (`.tmp/index`).
 - Make build system with generated rules.
 - Standard directory structure with modules as subdirectories.
@@ -37,6 +37,9 @@ single module.
   (auto-generated).
 - `coverage_${module}.html` - HTML coverage report (auto-generated from
   self-coverage).
+- `coverage_${module}.stdout`, `coverage_${module}_self.stdout` -
+  Captured raw `go test` output for the integration and per-package
+  runs. Kept for failure inspection.
 
 **Key features**:
 
@@ -181,6 +184,8 @@ The system uses an intelligent dual coverage display:
 ├── coverage_<module>.func            # Integration function reports
 ├── coverage_<module>_self.func       # Self-coverage function reports
 ├── coverage_<module>.html            # HTML report
+├── coverage_<module>.stdout          # Raw integration test output
+├── coverage_<module>_self.stdout     # Raw per-package test output
 ├── coverage_<module>/                # Individual package profiles
 │   └── <module-import-path>/
 │       ├── <package1>.prof


### PR DESCRIPTION
## Summary

Two-commit documentation cleanup. No code or build-system behaviour
changes.

### `docs: refactor AGENTS.md / BUILDING.md split for shared vs local content`

`BUILDING.md` is the canonical build-system reference shared across
darvaza.org repos; `AGENTS.md` is core-specific. This commit aligns
the files with that split:

- Moves shared content out of AGENTS.md and into BUILDING.md:
  safe `fieldalignment` workflow, Documentation Standards (with
  Common Documentation Issues and Writing Documentation Guidelines),
  DeepSource Configuration, Pre-commit Checklist (replacing the
  former Best Practices > Workflow; drops the redundant
  "no lint violations" item, adds an explicit `make test` step,
  generalises the doc-update items), and a Troubleshooting section.
- Strips per-repo leakage from BUILDING.md: the entire VS Code
  Integration section plus its mentions in Core Components,
  Directory Structure, IDE Integration, and Project Setup
  (per-repo concern, also stale after the native-import migration);
  the `golang.org/x/net` justification on the Go 1.24 floor;
  changelog-style prose in Coverage System and Codecov Integration.
- Renames `Go Linting (.golangci.yml)` →
  `golangci-lint Configuration` so the AGENTS.md cross-reference
  anchor matches.
- Slims AGENTS.md to the core-specific essentials (repository
  overview, code architecture, testing patterns pointer, and a
  Build & Tooling Reference block that cross-links into BUILDING.md
  by anchor) — 436 → 102 lines.

### `docs: fix factual errors in BUILDING.md and README-coverage.md`

- `README-coverage.md`: Go floor 1.23 → 1.24 (matches the rest of
  the project); documents the `.stdout` files written by
  `make_coverage.sh` (raw integration and per-package test output)
  in both the Generates list and the File Structure tree.
- `BUILDING.md`: directory tree gains `merge_coverage.sh` (already
  described in the Coverage Merge Utility subsection but missing
  from the tree) and the `claude.yml` / `claude-code-review.yml`
  workflows; the `.editorconfig` example is updated to match the
  actual file (`root = true`, `max_line_length = 80`, the
  `[*.{json,yaml,yml,md}]` grouping, and the `[{go.mod,go.sum}]`
  exemption).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganised repository guidance and development workflow documentation
  * Expanded build system guides with comprehensive tooling references and configuration details
  * Added troubleshooting section addressing common build and coverage issues
  * Updated minimum Go requirement to version 1.24
  * Enhanced coverage system documentation with additional output capture details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darvaza-proxy/core/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->