### PR TITLE
build: require Go 1.25+, update x/net to v0.56.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go-version: ['1.24', '1.25', '1.26']
+        go-version: ['1.25', '1.26']
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go-version: ['1.24', '1.25', '1.26']
+        go-version: ['1.25', '1.26']
     steps:
     - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ It serves as the base for other darvaza.org projects.
 
 ## Prerequisites
 
-- Go 1.24 or later (the project's minimum).
+- Go 1.25 or later (the project's minimum).
 - `make` available; `$GOPATH` configured.
 
 See [BUILDING.md → Required Tools](BUILDING.md#required-tools) for the

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -272,7 +272,7 @@ Tools are auto-detected and replaced with `true` (no-op) if unavailable.
 
 #### Required Tools
 
-- **Go 1.24+**: Required minimum.
+- **Go 1.25+**: Required minimum.
 - **golangci-lint**: Go code linting (version selected by Go version).
 - **revive**: Additional Go linting rules.
 - **make**: Build orchestration.
@@ -294,7 +294,7 @@ The coverage system provides comprehensive testing:
 
 GitHub Actions workflows provide:
 
-- **Build Testing**: Tests across Go 1.24, 1.25 and 1.26.
+- **Build Testing**: Tests across Go 1.25 and 1.26.
 - **Race Detection**: Dedicated workflow for race condition testing.
 - **Coverage Reporting**: Automatic Codecov uploads.
 - **Dependency Updates**: Automated Renovate PRs.
@@ -544,7 +544,7 @@ The build system integrates with development environments:
 
 GitHub Actions workflows provide:
 
-- **Multi-version Testing**: Go 1.24, 1.25 and 1.26.
+- **Multi-version Testing**: Go 1.25 and 1.26.
 - **Coverage Reporting**: Automatic Codecov uploads.
 - **Dependency Management**: Renovate integration.
 - **Branch Protection**: WIP branch exclusion.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ COVERAGE_DIR ?= $(TMPDIR)/coverage
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 v2.8.0 v2.11.4)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.24 v1.14.0 v1.15.0)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.25 v2.11.4)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.25 v1.15.0)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT_RUN_ARGS ?= --show-stats=false

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Context-aware error group with cancellation:
 
 ## Development
 
-**Requirements:** Go 1.24 or later
+**Requirements:** Go 1.25 or later
 
 For detailed development setup, build commands, and AI agent guidance:
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module darvaza.org/core
 
-go 1.24.0
+go 1.25.0
 
-require golang.org/x/net v0.50.0
+require golang.org/x/net v0.56.0
 
-require golang.org/x/text v0.34.0 // indirect
+require golang.org/x/text v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
-golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
-golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=

--- a/internal/build/README-coverage.md
+++ b/internal/build/README-coverage.md
@@ -13,7 +13,7 @@ The coverage system generates two types of coverage data:
 
 ## Prerequisites
 
-- Go 1.24 or later.
+- Go 1.25 or later.
 - A monorepo with modules defined in an index file (`.tmp/index`).
 - Make build system with generated rules.
 - Standard directory structure with modules as subdirectories.

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "packageRules": [
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "1.22"
+      "allowedVersions": "1.25"
     }
   ],
   "postUpdateOptions": [

--- a/spinlock_test.go
+++ b/spinlock_test.go
@@ -260,15 +260,13 @@ func runContentionBenchmark(b *testing.B, sl *SpinLock) {
 	iterations := b.N / numWorkers
 
 	for range numWorkers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range iterations {
 				sl.Lock()
 				_ = runtime.NumGoroutine()
 				sl.Unlock()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/sync.go
+++ b/sync.go
@@ -61,12 +61,9 @@ func (wg *WaitGroup) Go(fn func() error) {
 // to intercept the returned error
 func (wg *WaitGroup) GoCatch(fn func() error, catch func(error) error) {
 	if fn != nil {
-		wg.wg.Add(1)
-
-		go func() {
-			defer wg.wg.Done()
+		wg.wg.Go(func() {
 			wg.run(fn, catch)
-		}()
+		})
 	}
 }
 

--- a/testing.go
+++ b/testing.go
@@ -804,13 +804,11 @@ func doLog(t T, prefixFormat string, prefixArgs []any, messageFormat string, mes
 func runWorkers(numWorkers int, worker func(int) error, errCh chan error) {
 	var wg sync.WaitGroup
 	for i := range numWorkers {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			if err := worker(id); err != nil {
+		wg.Go(func() {
+			if err := worker(i); err != nil {
 				errCh <- err
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 	close(errCh)


### PR DESCRIPTION
## Summary

Updates `golang.org/x/net` to v0.56.0 to clear the moderate vulnerability
Dependabot reports against the default branch — the HTML-parser
denial-of-service GHSA-5cv4-jp36-h3mw, patched from v0.55.0. Because
`x/net` has declared `go 1.25` since v0.51.0, taking the fix raises the
minimum Go version to **1.25** and 1.24 leaves the supported matrix.

This narrows CI to two releases (1.25, 1.26) for now; Go 1.27 restores the
usual three-version window.

## Dependency changes

- `golang.org/x/net` v0.50.0 → v0.56.0 (security fix).
- `golang.org/x/text` v0.34.0 → v0.39.0 (indirect, pulled by x/net).
- `go` directive 1.24.0 → 1.25.0.

## Consequences of the floor bump

With 1.24 gone, the Go-version-keyed tool tiers collapse to a single
value each — `get_version.sh` now selects golangci-lint v2.11.4 and
revive v1.15.0 unconditionally.

That newer linter tier, combined with the 1.25 floor, enables the
`modernize` analyser and revive's `use-waitgroup-go` rule. Three
`Add(1)` / `go func()` / `defer Done()` sites are rewritten to
`sync.WaitGroup.Go` (added in Go 1.25):

- `sync.go` — `WaitGroup.GoCatch` (production).
- `testing.go` — `runWorkers` helper (also drops the pre-1.22
  `func(id int){…}(i)` loop-capture workaround).
- `spinlock_test.go` — contention benchmark helper.

The rewrites are behaviour-preserving: `WaitGroup.Go` is exactly
`Add(1)` plus a deferred `Done()`. Verified under `make race`.

## Housekeeping

- CI build/test matrices drop `1.24`.
- Prerequisite docs (AGENTS.md, BUILDING.md, README.md,
  README-coverage.md) state the 1.25 minimum.
- Renovate's stale Go constraint corrected (1.22 → 1.25).

## Verification

- `make tidy` — clean.
- `make test` — pass.
- `make race` — pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to require Go 1.25 or later.
  * Refreshed documentation to reflect the new minimum Go version and the current CI testing matrix.

* **Bug Fixes**
  * Adjusted build and test workflows to run against Go 1.25 and 1.26 only.
  * Updated tool and dependency version settings to stay aligned with the supported Go release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->