### PR TITLE
slices: deprecate the helpers with direct stdlib slices counterparts

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ Key distinctions from `IsZero`:
 
 #### Search and Comparison
 
-* `SliceContains[T](slice, value)` - check if slice contains value.
+* ~~`SliceContains[T](slice, value)`~~ - deprecated, use `slices.Contains`.
 * `SliceContainsFn[T](slice, value, eq)` - check containment with custom
   equality.
-* `SliceEqual[T](a, b)` - compare two slices for equality.
-* `SliceEqualFn[T](a, b, eq)` - compare slices with custom equality function.
+* ~~`SliceEqual[T](a, b)`~~ - deprecated, use `slices.Equal`.
+* ~~`SliceEqualFn[T](a, b, eq)`~~ - deprecated, use `slices.EqualFunc`.
 
 #### Transformation
 
@@ -160,7 +160,7 @@ Key distinctions from `IsZero`:
 * `SliceMap[T1,T2](slice, fn)` - transform each element with cumulative
   function.
 * `SliceReplaceFn[T](slice, fn)` - replace/filter elements in-place.
-* `SliceCopy[T](slice)` - create shallow copy of slice.
+* ~~`SliceCopy[T](slice)`~~ - deprecated, use `slices.Clone`.
 * `SliceCopyFn[T](slice, fn)` - create filtered/transformed copy.
 
 #### Set Operations
@@ -174,10 +174,10 @@ Key distinctions from `IsZero`:
 
 #### Sorting and Ordering
 
-* `SliceSort[T](slice, cmp)` - sort using comparison function (returns int).
+* ~~`SliceSort[T](slice, cmp)`~~ - deprecated, use `slices.SortFunc`.
 * `SliceSortFn[T](slice, less)` - sort using less function (returns bool).
-* `SliceSortOrdered[T](slice)` - sort ordered types (int, string, float64).
-* `SliceReverse[T](slice)` - reverse slice in-place.
+* ~~`SliceSortOrdered[T](slice)`~~ - deprecated, use `slices.Sort`.
+* ~~`SliceReverse[T](slice)`~~ - deprecated, use `slices.Reverse`.
 * `SliceReversed[T](slice)` - return reversed copy.
 * `SliceReversedFn[T](slice, fn)` - return transformed and reversed copy.
 

--- a/slices.go
+++ b/slices.go
@@ -30,6 +30,8 @@ func SliceMinusFn[T any](a, b []T, eq func(T, T) bool) []T {
 }
 
 // SliceContains tells if a slice contains a given element
+//
+// Deprecated: Use [slices.Contains] instead.
 func SliceContains[T comparable](a []T, v T) bool {
 	return SliceContainsFn(a, v, func(va, vb T) bool {
 		return va == vb
@@ -48,6 +50,8 @@ func SliceContainsFn[T any](a []T, v T, eq func(T, T) bool) bool {
 }
 
 // SliceEqual tells if two slices are equal.
+//
+// Deprecated: Use [slices.Equal] instead.
 func SliceEqual[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
@@ -59,6 +63,8 @@ func SliceEqual[T comparable](a, b []T) bool {
 }
 
 // SliceEqualFn tells if two slices are equal using a comparing helper.
+//
+// Deprecated: Use [slices.EqualFunc] instead.
 func SliceEqualFn[T any](a, b []T, eq func(va, vb T) bool) bool {
 	if len(a) != len(b) || eq == nil {
 		return false
@@ -196,6 +202,8 @@ func SliceCopyFn[T any](s []T,
 }
 
 // SliceCopy makes a shallow copy of a given slice
+//
+// Deprecated: Use [slices.Clone] instead.
 func SliceCopy[T any](s []T) []T {
 	l := len(s)
 	result := make([]T, l)
@@ -250,6 +258,8 @@ func SliceSortFn[T any](x []T, less func(a, b T) bool) {
 // function. This sort is not guaranteed to be stable.
 // cmp(a, b) should return a negative number when a < b, a positive number when
 // a > b and zero when a == b.
+//
+// Deprecated: Use [slices.SortFunc] instead.
 func SliceSort[T any](x []T, cmp func(a, b T) int) {
 	if cmp != nil && len(x) > 0 {
 		slices.SortFunc(x, cmp)
@@ -257,6 +267,8 @@ func SliceSort[T any](x []T, cmp func(a, b T) int) {
 }
 
 // SliceSortOrdered sorts the slice x of an [Ordered] type in ascending order.
+//
+// Deprecated: Use [slices.Sort] instead.
 func SliceSortOrdered[T Ordered](x []T) {
 	if len(x) > 0 {
 		slices.Sort(x)
@@ -320,6 +332,8 @@ func doP[T any](x []T, p float64, less func(a, b T) bool) T {
 
 // SliceReverse modifies a slice reversing the order of its
 // elements.
+//
+// Deprecated: Use [slices.Reverse] instead.
 func SliceReverse[T any](x []T) {
 	l := len(x)
 	if l > 1 {


### PR DESCRIPTION
## Summary

Marks seven `Slice*` helpers as deprecated where the standard library
`slices` package already provides a one-to-one equivalent, and points
callers there. Continues the deprecation review that retired `SpinLock`.

## Deprecated

| Helper | Replacement |
|--------|-------------|
| `SliceContains` | `slices.Contains` |
| `SliceEqual` | `slices.Equal` |
| `SliceEqualFn` | `slices.EqualFunc` |
| `SliceCopy` | `slices.Clone` |
| `SliceSort` | `slices.SortFunc` |
| `SliceSortOrdered` | `slices.Sort` |
| `SliceReverse` | `slices.Reverse` |

Each gains a `// Deprecated:` doc comment with a `[slices.X]` doc link,
and the matching README entries are struck through.

## Left untouched

The speciality helpers with no stdlib counterpart stay: the `*Fn`
variants (custom equality/less), `SliceMap`, `SliceReplaceFn`,
`SliceUnique`/`SliceUniquify`, `SliceMinus`, `SliceRandom`, `SliceP`,
`SliceReversed`/`SliceReversedFn`, `SliceCopyFn` and `SliceSortFn`.

Two look like stdlib duplicates but are not: `SliceSortFn` takes a
`less` bool function, which `slices.SortFunc` (a cmp-style int) does
not cover; and `SliceUnique` removes all duplicates, where
`slices.Compact` only collapses adjacent ones.

## No breakage

Every caller of the deprecated helpers lives inside `core` itself —
their own internal use and the in-package tests — so staticcheck's
SA1019 does not flag them and the build stays clean.

## Verification

- `make tidy` — clean (golangci-lint, incl. staticcheck SA1019 and modernize).
- `make check-spelling` — 0 issues.
- `make test` — pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated slice utility docs to mark several helpers as deprecated.
  * Added guidance pointing to the matching Go `slices` package alternatives.
  * Clarified which slice helpers remain supported and kept their descriptions aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->