### PR TITLE
feat: add StringError and migrate error sentinels to constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,17 @@ Key distinctions from `IsZero`:
 
 ## Error Handling
 
-### Standard Error Variables
+### Standard Error Sentinels
 
-Predefined error values for common conditions:
+Predefined errors for common conditions. All are `StringError` constants
+except `ErrTODO` (a wrapped error) and `ErrInvalid` (an alias of
+`fs.ErrInvalid`):
 
 * `ErrNotImplemented` - functionality not yet implemented.
 * `ErrTODO` - placeholder for future implementation.
-* `ErrExists` - resource already exists.
-* `ErrNotExists` - resource does not exist.
+* `ErrExists` - resource already exists (distinct from `fs.ErrExist`).
+* `ErrNotExists` - resource does not exist (distinct from
+  `fs.ErrNotExist`).
 * `ErrInvalid` - invalid input or state.
 * `ErrUnknown` - unknown or unspecified error.
 * `ErrNilReceiver` - method called on nil receiver.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,27 @@ Predefined error values for common conditions:
 * `ErrNilReceiver` - method called on nil receiver.
 * `ErrUnreachable` - indicates impossible condition.
 
+### String Errors
+
+The `StringError` type is an error whose message is the string itself.
+Because its underlying type is `string`, sentinels can be declared as
+constants rather than variables:
+
+```go
+const ErrClosed core.StringError = "already closed"
+```
+
+* Values with equal text compare equal, so `errors.Is` matches by value.
+* `.AsError()` returns nil for the empty string, following the
+  `AsError()` convention used across the package.
+* `.OK()` reports whether the string is empty (no error), the inverse of
+  a non-nil `.AsError()`.
+* `.IsZero()` reports whether the string is empty, so `IsZero` recognises
+  a zero `StringError` through its own method.
+* `NewStringError(format, args...)` - build one from a formatted message,
+  returning nil when the result is empty. Without arguments the format is
+  used verbatim, leaving a literal `%` untouched.
+
 ### Error Wrapping
 
 The `Unwrappable` interface represents the classic `Unwrap() error` pattern,

--- a/errors.go
+++ b/errors.go
@@ -1,31 +1,38 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"slices"
 )
 
-var (
+// Sentinel errors for common conditions. Except for [ErrTODO] and
+// [ErrInvalid], these are [StringError] constants: they can't be
+// reassigned and match by value.
+const (
 	// ErrNotImplemented indicates something hasn't been implemented yet
-	ErrNotImplemented = errors.New("not implemented")
+	ErrNotImplemented StringError = "not implemented"
+	// ErrExists indicates something already exists. It is deliberately
+	// general, distinct from the file-centric [fs.ErrExist].
+	ErrExists StringError = "already exists"
+	// ErrNotExists indicates something doesn't exist. It is deliberately
+	// general, distinct from the file-centric [fs.ErrNotExist].
+	ErrNotExists StringError = "does not exist"
+	// ErrUnknown indicates something isn't recognized
+	ErrUnknown StringError = "unknown"
+	// ErrNilReceiver indicates a method was called over a nil instance
+	ErrNilReceiver StringError = "nil receiver"
+	// ErrUnreachable indicates something impossible happened
+	ErrUnreachable StringError = "unreachable"
+)
+
+var (
 	// ErrTODO is like ErrNotImplemented but used especially to
 	// indicate something needs to be implemented
 	ErrTODO = Wrap(ErrNotImplemented, "TODO")
-	// ErrExists indicates something already exists
-	ErrExists = errors.New("already exists")
-	// ErrNotExists indicates something doesn't exist
-	ErrNotExists = errors.New("does not exist")
 	// ErrInvalid indicates an argument isn't valid. It's an alias of
 	// [fs.ErrInvalid] so errors.Is matches across the boundary.
 	ErrInvalid = fs.ErrInvalid
-	// ErrUnknown indicates something isn't recognized
-	ErrUnknown = errors.New("unknown")
-	// ErrNilReceiver indicates a method was called over a nil instance
-	ErrNilReceiver = errors.New("nil receiver")
-	// ErrUnreachable indicates something impossible happened
-	ErrUnreachable = errors.New("unreachable")
 )
 
 var (

--- a/stringerror.go
+++ b/stringerror.go
@@ -1,0 +1,62 @@
+package core
+
+import "fmt"
+
+// StringError is an error whose message is the string value itself.
+//
+// Unlike an error from [errors.New], a StringError can be declared as a
+// constant, so sentinels become immutable typed constants instead of
+// package-level variables:
+//
+//	const ErrClosed StringError = "already closed"
+//
+// Values with equal text compare equal, so [errors.Is] matches
+// StringError sentinels by value without a dedicated Is method.
+type StringError string
+
+// Compile-time checks that StringError is usable as a constant and
+// satisfies the error interface.
+const _ StringError = "boom"
+
+var _ error = StringError("boom")
+
+// Error returns the message, which is the string value itself.
+func (e StringError) Error() string {
+	return string(e)
+}
+
+// AsError returns the receiver as an error, or nil when its text is
+// empty, so a zero StringError stands for "no error". It follows the
+// AsError() convention recognised by [AsError].
+func (e StringError) AsError() error {
+	if e == "" {
+		return nil
+	}
+	return e
+}
+
+// OK reports whether the StringError is empty, meaning it represents no
+// error. It is the inverse of a non-nil [StringError.AsError] result.
+func (e StringError) OK() bool {
+	return e == ""
+}
+
+// IsZero reports whether the StringError is empty. It lets [IsZero]
+// recognise a zero StringError through the IsZero() convention.
+func (e StringError) IsZero() bool {
+	return e == ""
+}
+
+// NewStringError formats its arguments into a [StringError]. Without
+// arguments the format string becomes the message verbatim, so a literal
+// per-cent sign is left untouched. It returns nil when the message is
+// empty, matching [StringError.AsError].
+func NewStringError(format string, args ...any) error {
+	var s StringError
+	if len(args) > 0 {
+		s = StringError(fmt.Sprintf(format, args...))
+	} else {
+		s = StringError(format)
+	}
+	return s.AsError()
+}

--- a/stringerror_test.go
+++ b/stringerror_test.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"errors"
+	"testing"
+)
+
+// Compile-time verification that test case types implement TestCase.
+var (
+	_ TestCase = stringErrorTestCase{}
+	_ TestCase = stringErrorIsTestCase{}
+	_ TestCase = stringErrorCtorTestCase{}
+)
+
+// errStringSentinel exercises the constant-sentinel pattern StringError
+// exists for.
+const errStringSentinel StringError = "sentinel"
+
+// stringErrorTestCase checks Error() and AsError() for a StringError.
+type stringErrorTestCase struct {
+	name    string
+	input   StringError
+	wantMsg string
+	wantNil bool
+}
+
+func newStringErrorTestCase(name string, input StringError, wantMsg string,
+	wantNil bool) stringErrorTestCase {
+	return stringErrorTestCase{
+		name:    name,
+		input:   input,
+		wantMsg: wantMsg,
+		wantNil: wantNil,
+	}
+}
+
+func (tc stringErrorTestCase) Name() string {
+	return tc.name
+}
+
+func (tc stringErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	AssertEqual(t, tc.wantMsg, tc.input.Error(), "Error")
+	// OK(), IsZero() and a nil AsError() all track emptiness together.
+	AssertEqual(t, tc.wantNil, tc.input.OK(), "OK")
+	AssertEqual(t, tc.wantNil, tc.input.IsZero(), "IsZero")
+
+	err := tc.input.AsError()
+	if tc.wantNil {
+		AssertNil(t, err, "AsError")
+		return
+	}
+
+	AssertNotNil(t, err, "AsError")
+	AssertEqual(t, tc.wantMsg, err.Error(), "AsError message")
+}
+
+func stringErrorTestCases() []stringErrorTestCase {
+	return []stringErrorTestCase{
+		newStringErrorTestCase("empty", "", "", true),
+		newStringErrorTestCase("simple", "boom", "boom", false),
+		newStringErrorTestCase("with spaces", "file not found",
+			"file not found", false),
+		newStringErrorTestCase("blank is not empty", " ", " ", false),
+	}
+}
+
+func TestStringError(t *testing.T) {
+	RunTestCases(t, stringErrorTestCases())
+}
+
+// stringErrorIsTestCase checks StringError identity matching through
+// both errors.Is and the package's IsError, which must agree.
+type stringErrorIsTestCase struct {
+	err    error
+	target error
+	name   string
+	want   bool
+}
+
+func newStringErrorIsTestCase(name string, err, target error,
+	want bool) stringErrorIsTestCase {
+	return stringErrorIsTestCase{
+		name:   name,
+		err:    err,
+		target: target,
+		want:   want,
+	}
+}
+
+func (tc stringErrorIsTestCase) Name() string {
+	return tc.name
+}
+
+func (tc stringErrorIsTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	AssertEqual(t, tc.want, errors.Is(tc.err, tc.target), "errors.Is")
+	AssertEqual(t, tc.want, IsError(tc.err, tc.target), "IsError")
+}
+
+func stringErrorIsTestCases() []stringErrorIsTestCase {
+	return []stringErrorIsTestCase{
+		newStringErrorIsTestCase("same value",
+			StringError("boom"), StringError("boom"), true),
+		newStringErrorIsTestCase("sentinel constant",
+			errStringSentinel, StringError("sentinel"), true),
+		newStringErrorIsTestCase("different value",
+			StringError("boom"), StringError("bang"), false),
+		newStringErrorIsTestCase("wrapped sentinel",
+			Wrap(errStringSentinel, "context"), errStringSentinel, true),
+	}
+}
+
+func TestStringErrorIs(t *testing.T) {
+	RunTestCases(t, stringErrorIsTestCases())
+}
+
+// stringErrorCtorTestCase checks NewStringError formatting and its
+// empty-to-nil behaviour.
+type stringErrorCtorTestCase struct {
+	format  string
+	name    string
+	wantMsg string
+	args    []any
+	wantNil bool
+}
+
+func newStringErrorCtorTestCase(name, format string, args []any,
+	wantMsg string, wantNil bool) stringErrorCtorTestCase {
+	return stringErrorCtorTestCase{
+		args:    args,
+		format:  format,
+		name:    name,
+		wantMsg: wantMsg,
+		wantNil: wantNil,
+	}
+}
+
+func (tc stringErrorCtorTestCase) Name() string {
+	return tc.name
+}
+
+func (tc stringErrorCtorTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	err := NewStringError(tc.format, tc.args...)
+	if tc.wantNil {
+		AssertNil(t, err, "NewStringError")
+		return
+	}
+
+	AssertNotNil(t, err, "NewStringError")
+	AssertEqual(t, tc.wantMsg, err.Error(), "message")
+	AssertErrorIs(t, err, StringError(tc.wantMsg), "matches sentinel")
+}
+
+func stringErrorCtorTestCases() []stringErrorCtorTestCase {
+	return []stringErrorCtorTestCase{
+		newStringErrorCtorTestCase("plain", "boom", nil, "boom", false),
+		newStringErrorCtorTestCase("empty", "", nil, "", true),
+		newStringErrorCtorTestCase("formatted", "%s: %d",
+			S[any]("code", 42), "code: 42", false),
+		newStringErrorCtorTestCase("literal percent", "50% off", nil,
+			"50% off", false),
+	}
+}
+
+func TestNewStringError(t *testing.T) {
+	RunTestCases(t, stringErrorCtorTestCases())
+}
+
+// TestStringErrorGenericHelpers confirms StringError's methods are picked
+// up by the generic AsError and IsZero helpers.
+func TestStringErrorGenericHelpers(t *testing.T) {
+	AssertNil(t, AsError(StringError("")), "empty via AsError")
+	AssertError(t, AsError(StringError("boom")), "non-empty via AsError")
+	AssertTrue(t, IsZero(StringError("")), "empty via IsZero")
+	AssertFalse(t, IsZero(StringError("boom")), "non-empty via IsZero")
+}


### PR DESCRIPTION
## Summary

Adds `StringError`, an error whose message is the string value itself,
and migrates the package's leaf error sentinels to `StringError`
constants.

Because its underlying type is `string`, a `StringError` can be declared
as a constant, so error sentinels become immutable typed constants
instead of package-level variables. Values with equal text compare
equal, so `errors.Is` matches by value without a dedicated `Is` method.

## Changes

**feat: add StringError, a constant-capable error type**

- `StringError` type with `Error()`.
- `AsError()`, `OK()`, and `IsZero()` treat an empty string as "no
  error", plugging into the package's existing `AsError()` / `OK()` /
  `IsZero` conventions.
- `NewStringError(format, args...)` builds one from a formatted message,
  verbatim when arg-less, returning nil when empty.

**refactor: make error sentinels StringError constants**

- `ErrNotImplemented`, `ErrExists`, `ErrNotExists`, `ErrUnknown`,
  `ErrNilReceiver`, and `ErrUnreachable` are now `StringError` constants.
- `ErrTODO` stays a var — it wraps `ErrNotImplemented` — and `ErrInvalid`
  stays an alias of `fs.ErrInvalid` to keep identity across the `fs`
  boundary.
- `ErrExists` / `ErrNotExists` are deliberately general, distinct from
  the file-centric `fs.ErrExist` / `fs.ErrNotExist`.

## Compatibility

Sentinel matching moves from pointer identity to value equality. This is
not breaking for normal consumers: `errors.Is`, direct comparison, and
returning or wrapping the sentinels all recompile and behave the same,
since Go resolves a module path to a single version per build. The only
source-level breaks are reassigning a sentinel or taking its address,
both of which are abuse of another package's API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `StringError` type for immutable, value-based error handling.
  * Added helpers to identify empty errors and convert them to `nil`.
  * Added `NewStringError` for creating formatted errors, including empty-message handling.
  * Standard error sentinels now support consistent value-based matching.

* **Documentation**
  * Updated error documentation with sentinel details and `StringError` usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->