### PR TITLE
feat: decide Assert equality with AreEqual, add the DeepEqual family

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -297,7 +297,10 @@ The coverage system provides comprehensive testing:
 GitHub Actions workflows provide:
 
 - **Build Testing**: Tests across Go 1.25 and 1.26.
-- **Race Detection**: Dedicated workflow for race condition testing.
+- **Cross-platform Testing**: `platforms.yml` vets every `GOOS` and runs
+  the test and race suites natively on Linux, macOS and Windows. The
+  macOS and Windows jobs are gated behind the cheap Linux ones, so a
+  compile error fails fast without billing the premium runners.
 - **Coverage Reporting**: Automatic Codecov uploads.
 - **Dependency Updates**: Automated Renovate PRs.
 - **Branch Protection**: Ignores WIP branches.
@@ -507,7 +510,8 @@ make check-grammar
 
 - **`GO`**: Go command (default: `go`).
 - **`GOTEST_FLAGS`**: Additional test flags.
-- **`GOUP_FLAGS`**: Flags for dependency updates.
+- **`GOUP_FLAGS`**: Flags for dependency updates (default: `-v`).
+- **`GOVET_FLAGS`**: Additional vet flags (default: `-v`).
 - **`COVERAGE_HTML`**: Generate HTML coverage reports.
 - **`JQ`**: JSON processor command.
 

--- a/README.md
+++ b/README.md
@@ -572,10 +572,15 @@ both `*testing.T` and `MockT`:
 
 #### Basic Assertions
 
-* `AssertEqual[T](t, expected, actual, name...)` - generic value comparison.
+* `AssertEqual[T](t, expected, actual, name...)` - generic value comparison,
+  decided by `AreEqual`.
 * `AssertNotEqual[T](t, expected, actual, name...)` - generic inequality
-  comparison.
-* `AssertSliceEqual[T](t, expected, actual, name...)` - slice comparison using
+  comparison, decided by `AreEqual`.
+* `AssertSliceEqual[T](t, expected, actual, name...)` - slice comparison,
+  settling length and nil-ness first, then the elements via `AreEqual`.
+* `AssertDeepEqual[T](t, expected, actual, name...)` - value comparison using
+  `reflect.DeepEqual`.
+* `AssertNotDeepEqual[T](t, expected, actual, name...)` - inequality using
   `reflect.DeepEqual`.
 * `AssertSame(t, expected, actual, name...)` - same value/reference comparison
   using pointer equality for reference types, value equality for basic types.
@@ -587,6 +592,17 @@ both `*testing.T` and `MockT`:
   checking.
 * `AssertContains(t, text, substring, name...)` - string containment.
 * `AssertNotContain(t, text, substring, name...)` - string exclusion.
+
+The `Equal` family delegates to `AreEqual`, so it accepts values that aren't
+comparable and honours an `Equal(T) bool` method. `AssertDeepEqual` and its
+`Must` form settle what it cannot decide — nested slices, and anything else
+needing a deep traversal — which the failure names as such.
+
+`AssertSliceEqual` settles shape before contents: a length difference is
+reported as a count, and nil-versus-empty by name, since only nil equals nil
+and both otherwise print as an indistinguishable `[]`. Once the shape matches,
+the first element known to differ is reported by index, so a long slice needn't
+be diffed by eye.
 
 #### Error and Type Assertions
 
@@ -623,6 +639,10 @@ methods terminate execution, similar to `t.Error()` vs `t.Fatal()`.
 * `AssertMustNotEqual[T](t, expected, actual, name...)` - terminate on equality.
 * `AssertMustSliceEqual[T](t, expected, actual, name...)` - terminate on slice
   inequality.
+* `AssertMustDeepEqual[T](t, expected, actual, name...)` - terminate on deep
+  inequality.
+* `AssertMustNotDeepEqual[T](t, expected, actual, name...)` - terminate on deep
+  equality.
 * `AssertMustTrue(t, condition, name...)` /
   `AssertMustFalse(t, condition, name...)` - terminate on boolean mismatch.
 * `AssertMustNil(t, value, name...)` / `AssertMustNotNil(t, value, name...)` -

--- a/TESTING.md
+++ b/TESTING.md
@@ -146,6 +146,8 @@ for log messages, not a complete message:
 core.AssertEqual(t, expected, actual, "value")
 core.AssertNotEqual(t, expected, actual, "value")
 core.AssertSliceEqual(t, expectedSlice, actualSlice, "slice")
+core.AssertDeepEqual(t, expected, actual, "value")
+core.AssertNotDeepEqual(t, expected, actual, "value")
 core.AssertSame(t, expected, actual, "same reference/value")
 core.AssertNotSame(t, expected, actual, "different reference/value")
 core.AssertTrue(t, condition, "condition")
@@ -153,6 +155,32 @@ core.AssertFalse(t, condition, "negation")
 core.AssertNil(t, value, "nil check")
 core.AssertNotNil(t, value, "non-nil check")
 ```
+
+**Choosing between `Equal` and `DeepEqual`:**
+
+Reach for `AssertEqual` first. It delegates to `core.AreEqual`, so it takes
+values that aren't comparable — a slice, a map — and honours an
+`Equal(T) bool` method where the type defines one.
+
+`AreEqual` walks a slice one level deep and no further. A pair it cannot
+settle fails the assertion, reporting that the values need a deep
+comparison. That is the signal to switch to `AssertDeepEqual`, or
+`AssertMustDeepEqual` where the assertion should abort. The failure names
+no function to call: a base assertion cannot tell whether its caller came
+through a `Must` wrapper, and sending a `Must` caller to a non-`Must`
+function would trade their abort away silently.
+
+The deep form is a fallback, not a stronger one. `reflect.DeepEqual` never
+asks the type, so a lenient `Equal` method passes `AssertEqual` and fails
+`AssertDeepEqual` — and a slice falling back withdraws that treatment from
+every element as well. Worth knowing before taking the advice the failure
+gives.
+
+`AssertSliceEqual` settles shape before contents. A length difference is
+reported as a count, and nil-versus-empty by name, since only nil equals
+nil and both otherwise print as an indistinguishable `[]`. Once the shape
+matches, the first element known to differ is reported by index, sparing
+the reader a long pair of slices to diff by eye.
 
 **Error Assertions:**
 

--- a/TESTING_core.md
+++ b/TESTING_core.md
@@ -16,9 +16,11 @@ proper testing, especially when testing the assertion functions themselves.
 
 ```text
 Independent Base Functions:
-├── AssertEqual[T]         (standalone implementation)
-├── AssertNotEqual[T]      (standalone implementation)
-├── AssertSliceEqual[T]    (uses reflect.DeepEqual)
+├── AssertEqual[T]         (uses AreEqual)
+├── AssertNotEqual[T]      (uses AreEqual)
+├── AssertSliceEqual[T]    (uses AreEqual)
+├── AssertDeepEqual[T]     (uses reflect.DeepEqual)
+├── AssertNotDeepEqual[T]  (uses reflect.DeepEqual)
 ├── AssertContains         (uses strings.Contains)
 ├── AssertNotContain       (uses strings.Contains)
 ├── AssertNil              (uses IsNil utility)

--- a/testing.go
+++ b/testing.go
@@ -280,49 +280,66 @@ func RunTestCases[T TestCase](t *testing.T, cases []T) {
 }
 
 // AssertEqual compares two values and reports differences.
-// This is a generic helper that works with any comparable type.
+// Equality is decided by [AreEqual], so the values need not be
+// comparable: typed nils, identity, an Equal(T) bool method, and
+// slices one level deep all settle the answer without panicking.
 // The name parameter can include printf-style formatting.
 // Returns true if the assertion passed, false otherwise.
+// [AssertDeepEqual] settles what [AreEqual] cannot decide.
 //
 // Example usage:
 //
 //	AssertEqual(t, 42, result, "result value")
 //	AssertEqual(t, "hello", str, "string %d comparison", 1)
-func AssertEqual[U comparable](t T, expected, actual U, name string, args ...any) bool {
+func AssertEqual[U any](t T, expected, actual U, name string, args ...any) bool {
 	t.Helper()
-	ok := actual == expected
-	if !ok {
+	switch is, known := AreEqual(expected, actual); {
+	case !known:
+		doError(t, name, args, "undecided for %T, needs a deep comparison", actual)
+		return false
+	case !is:
 		doError(t, name, args, "expected %v, got %v", expected, actual)
-	} else {
+		return false
+	default:
 		doLog(t, name, args, "%v", actual)
+		return true
 	}
-	return ok
 }
 
 // AssertNotEqual compares two values and ensures they are different.
-// This is a generic helper that works with any comparable type.
-// The name parameter can include printf-style formatting.
+// Inequality is decided by [AreEqual], so the values need not be
+// comparable. The name parameter can include printf-style formatting.
 // Returns true if the assertion passed, false otherwise.
+// [AssertNotDeepEqual] settles what [AreEqual] cannot decide.
 //
 // Example usage:
 //
 //	AssertNotEqual(t, 42, result, "result value")
 //	AssertNotEqual(t, "hello", str, "string %d comparison", 1)
-func AssertNotEqual[U comparable](t T, expected, actual U, name string, args ...any) bool {
+func AssertNotEqual[U any](t T, expected, actual U, name string, args ...any) bool {
 	t.Helper()
-	ok := actual != expected
-	if !ok {
-		doError(t, name, args, "expected not %v, got %v", expected, actual)
-	} else {
+	switch is, known := AreEqual(expected, actual); {
+	case !known:
+		doError(t, name, args, "undecided for %T, needs a deep comparison", actual)
+		return false
+	case is:
+		doError(t, name, args, "expected a different value, got %v", actual)
+		return false
+	default:
 		doLog(t, name, args, "%v", actual)
+		return true
 	}
-	return ok
 }
 
 // AssertSliceEqual compares two slices and reports differences.
-// This uses reflect.DeepEqual for comprehensive comparison.
+// Shape is settled first — a length difference is reported as a count,
+// and nil-versus-empty by name, a nil slice being the equal of nil
+// alone. The elements are then decided by [AreEqual], and the first
+// known to differ is reported by index rather than as two whole slices.
 // The name parameter can include printf-style formatting.
 // Returns true if the assertion passed, false otherwise.
+// [AreEqual] walks one level deep. For nested or otherwise incomparable
+// elements, [AssertDeepEqual] takes a slice as readily as any other type.
 //
 // Example usage:
 //
@@ -330,9 +347,111 @@ func AssertNotEqual[U comparable](t T, expected, actual U, name string, args ...
 //	AssertSliceEqual(t, S("a", "b"), strings, "string slice %s", "test")
 func AssertSliceEqual[U any](t T, expected, actual []U, name string, args ...any) bool {
 	t.Helper()
+	switch {
+	case len(expected) != len(actual):
+		doError(t, name, args, "expected %d elements, got %d",
+			len(expected), len(actual))
+		return false
+	case (expected == nil) != (actual == nil):
+		doError(t, name, args, "expected %s slice, got %s slice",
+			emptySliceKind(expected), emptySliceKind(actual))
+		return false
+	}
+
+	switch is, known := AreEqual(expected, actual); {
+	case !known:
+		doError(t, name, args, "undecided for %s elements, needs a deep comparison",
+			reflect.TypeFor[U]())
+		return false
+	case !is:
+		doSliceDiffError(t, expected, actual, name, args)
+		return false
+	default:
+		doLog(t, name, args, "%v", actual)
+		return true
+	}
+}
+
+// emptySliceKind names an empty slice by its nil-ness, so a nil-versus-empty
+// mismatch reads as such instead of as two identical-looking "[]".
+func emptySliceKind[U any](s []U) string {
+	if s == nil {
+		return "nil"
+	}
+	return "empty"
+}
+
+// doSliceDiffError points at the first element known to differ, sparing
+// the reader a long pair of slices to diff by eye. Lengths are equal by
+// the time it is called.
+//
+// Only a decided difference is cited, because only a decided difference
+// settles the slice. An element [AreEqual] cannot judge is not excused
+// here: standing alone it fails the assertion as undecided before this
+// point is reached, so arriving here means something else settled the
+// verdict — and that is what the reader needs named.
+func doSliceDiffError[U any](t T, expected, actual []U, name string, args []any) {
+	t.Helper()
+	for i := range expected {
+		if is, known := AreEqual(expected[i], actual[i]); is || !known {
+			continue
+		}
+
+		doError(t, name, args, "index %d: expected %v, got %v",
+			i, expected[i], actual[i])
+		return
+	}
+
+	// Unreachable: the slice is decided element-wise, an Equal method on
+	// a named slice type being erased by the []U parameter, so a definite
+	// inequality always has a differing element to point at. Reported
+	// whole rather than silently passing if that ever stops holding.
+	doError(t, name, args, "expected %v, got %v", expected, actual)
+}
+
+// AssertDeepEqual compares two values with [reflect.DeepEqual].
+// It settles what [AssertEqual] leaves undecided, at the cost of the
+// deep traversal [AreEqual] avoids: unexported fields are inspected,
+// and cyclic data is followed until it repeats.
+// The name parameter can include printf-style formatting.
+// Returns true if the assertion passed, false otherwise.
+//
+// Prefer [AssertEqual] unless the values genuinely need the deep
+// comparison; it honours an Equal(T) bool method, which
+// [reflect.DeepEqual] ignores — elements included, so falling back here
+// from [AssertSliceEqual] withdraws that treatment from every element
+// as well.
+//
+// Example usage:
+//
+//	AssertDeepEqual(t, want, got, "parsed config")
+//	AssertDeepEqual(t, S(S(1, 2)), rows, "row %d", 1)
+func AssertDeepEqual[U any](t T, expected, actual U, name string, args ...any) bool {
+	t.Helper()
 	ok := reflect.DeepEqual(expected, actual)
 	if !ok {
 		doError(t, name, args, "expected %v, got %v", expected, actual)
+	} else {
+		doLog(t, name, args, "%v", actual)
+	}
+	return ok
+}
+
+// AssertNotDeepEqual compares two values with [reflect.DeepEqual] and
+// ensures they are different. It settles what [AssertNotEqual] leaves
+// undecided.
+// The name parameter can include printf-style formatting.
+// Returns true if the assertion passed, false otherwise.
+//
+// Example usage:
+//
+//	AssertNotDeepEqual(t, want, got, "parsed config")
+//	AssertNotDeepEqual(t, S(S(1, 2)), rows, "row %d", 1)
+func AssertNotDeepEqual[U any](t T, expected, actual U, name string, args ...any) bool {
+	t.Helper()
+	ok := !reflect.DeepEqual(expected, actual)
+	if !ok {
+		doError(t, name, args, "expected a different value, got %v", actual)
 	} else {
 		doLog(t, name, args, "%v", actual)
 	}
@@ -903,7 +1022,7 @@ func collectErrors(errCh chan error) error {
 //
 //	AssertMustEqual(t, 42, result, "result value")
 //	AssertMustEqual(t, "hello", str, "string %d comparison", 1)
-func AssertMustEqual[U comparable](t T, expected, actual U, name string, args ...any) {
+func AssertMustEqual[U any](t T, expected, actual U, name string, args ...any) {
 	t.Helper()
 	if !AssertEqual(t, expected, actual, name, args...) {
 		t.FailNow()
@@ -917,9 +1036,38 @@ func AssertMustEqual[U comparable](t T, expected, actual U, name string, args ..
 //
 //	AssertMustNotEqual(t, 42, result, "result value")
 //	AssertMustNotEqual(t, "hello", str, "string %d comparison", 1)
-func AssertMustNotEqual[U comparable](t T, expected, actual U, name string, args ...any) {
+func AssertMustNotEqual[U any](t T, expected, actual U, name string, args ...any) {
 	t.Helper()
 	if !AssertNotEqual(t, expected, actual, name, args...) {
+		t.FailNow()
+	}
+}
+
+// AssertMustDeepEqual calls AssertDeepEqual and t.FailNow() if the assertion fails.
+// This is a convenience function for tests that should terminate on assertion failure.
+//
+// Example usage:
+//
+//	AssertMustDeepEqual(t, want, got, "parsed config")
+//	AssertMustDeepEqual(t, S(S(1, 2)), rows, "row %d", 1)
+func AssertMustDeepEqual[U any](t T, expected, actual U, name string, args ...any) {
+	t.Helper()
+	if !AssertDeepEqual(t, expected, actual, name, args...) {
+		t.FailNow()
+	}
+}
+
+// AssertMustNotDeepEqual calls AssertNotDeepEqual and t.FailNow() if the
+// assertion fails.
+// This is a convenience function for tests that should terminate on assertion failure.
+//
+// Example usage:
+//
+//	AssertMustNotDeepEqual(t, want, got, "parsed config")
+//	AssertMustNotDeepEqual(t, S(S(1, 2)), rows, "row %d", 1)
+func AssertMustNotDeepEqual[U any](t T, expected, actual U, name string, args ...any) {
+	t.Helper()
+	if !AssertNotDeepEqual(t, expected, actual, name, args...) {
 		t.FailNow()
 	}
 }

--- a/testing_test.go
+++ b/testing_test.go
@@ -43,73 +43,192 @@ func TestS(t *testing.T) {
 	AssertSliceEqual(t, []int{42}, singleSlice, "S single element")
 }
 
+// undecidedPair returns two values AreEqual cannot settle: maps are
+// not comparable, and nil, identity and Equal methods all fail to
+// decide them.
+func undecidedPair() (a, b map[string]int) {
+	return map[string]int{"a": 1}, map[string]int{"a": 1}
+}
+
 // Test AssertEqual
 func TestAssertEqual(t *testing.T) {
 	mock := &MockT{}
 
-	// Test successful assertion
-	result := AssertEqual(mock, 42, 42, "equal test")
-	AssertTrue(t, result, "AssertEqual result when equal")
-	AssertFalse(t, mock.HasErrors(), "no errors on success")
-	AssertTrue(t, mock.HasLogs(), "has logs on success")
+	assertPassed(t, mock, AssertEqual(mock, 42, 42, "equal test"), "equal")
 
 	lastLog, ok := mock.LastLog()
 	AssertTrue(t, ok, "LastLog ok on success")
 	AssertEqual(t, "equal test: 42", lastLog, "log message on success")
 
 	mock.Reset()
+	assertFailed(t, mock, AssertEqual(mock, 42, 24, "not equal test"),
+		"expected 42, got 24", "not equal")
 
-	// Test failed assertion
-	result = AssertEqual(mock, 42, 24, "not equal test")
-	AssertFalse(t, result, "AssertEqual result when not equal")
-	AssertTrue(t, mock.HasErrors(), "has errors on failure")
-	AssertFalse(t, mock.HasLogs(), "no logs on failure")
+	// The point of the widened constraint: values == cannot compare at
+	// all, decided by AreEqual instead of rejected by the compiler.
+	mock.Reset()
+	assertPassed(t, mock, AssertEqual(mock, S(1, 2), S(1, 2), "slice test"),
+		"slice")
 
-	assertErrorContains(t, mock, "expected 42, got 24", "error message contains values")
+	mock.Reset()
+	assertPassed(t, mock, AssertEqual(mock, eqSlice{1}, eqSlice{1},
+		"Equal method test"), "Equal method")
+
+	mock.Reset()
+	a, b := undecidedPair()
+	assertFailed(t, mock, AssertEqual(mock, a, b, "undecided test"),
+		"undecided for map[string]int, needs a deep comparison", "undecided")
 }
 
 // Test AssertNotEqual
 func TestAssertNotEqual(t *testing.T) {
 	mock := &MockT{}
 
-	// Test successful assertion
-	result := AssertNotEqual(mock, 42, 24, "not equal test")
-	AssertTrue(t, result, "AssertNotEqual result when not equal")
-	AssertFalse(t, mock.HasErrors(), "no errors on success")
-	AssertTrue(t, mock.HasLogs(), "has logs on success")
+	assertPassed(t, mock, AssertNotEqual(mock, 42, 24, "not equal test"),
+		"not equal")
 
 	lastLog, ok := mock.LastLog()
 	AssertTrue(t, ok, "LastLog ok on success")
 	AssertEqual(t, "not equal test: 24", lastLog, "log message on success")
 
 	mock.Reset()
+	assertFailed(t, mock, AssertNotEqual(mock, 42, 42, "equal test"),
+		"expected a different value, got 42", "equal")
 
-	// Test failed assertion
-	result = AssertNotEqual(mock, 42, 42, "equal test")
-	AssertFalse(t, result, "AssertNotEqual result when equal")
-	AssertTrue(t, mock.HasErrors(), "has errors on failure")
-	AssertFalse(t, mock.HasLogs(), "no logs on failure")
+	// Undecided must fail rather than count as different: AreEqual
+	// reports (false, false) here, and reading only the first result
+	// would pass the assertion by accident.
+	mock.Reset()
+	assertPassed(t, mock, AssertNotEqual(mock, S(1, 2), S(1, 3), "slice test"),
+		"slice")
 
-	assertErrorContains(t, mock, "expected not 42, got 42", "error message contains values")
+	mock.Reset()
+	a, b := undecidedPair()
+	assertFailed(t, mock, AssertNotEqual(mock, a, b, "undecided test"),
+		"undecided for map[string]int, needs a deep comparison", "undecided")
 }
 
 // Test AssertSliceEqual
 func TestAssertSliceEqual(t *testing.T) {
 	mock := &MockT{}
 
-	// Test successful assertion
-	result := AssertSliceEqual(mock, S(1, 2, 3), S(1, 2, 3), "slice equal test")
-	AssertTrue(t, result, "AssertSliceEqual result when equal")
-	AssertFalse(t, mock.HasErrors(), "no errors on success")
-	AssertTrue(t, mock.HasLogs(), "has logs on success")
+	assertPassed(t, mock, AssertSliceEqual(mock, S(1, 2, 3), S(1, 2, 3),
+		"slice equal test"), "equal")
 
 	mock.Reset()
+	// The differing element is named, not left to be spotted.
+	assertFailed(t, mock, AssertSliceEqual(mock, S(1, 2, 3), S(1, 2, 4),
+		"slice not equal test"), "index 2: expected 3, got 4", "not equal")
 
-	// Test failed assertion
-	result = AssertSliceEqual(mock, S(1, 2, 3), S(1, 2, 4), "slice not equal test")
-	AssertFalse(t, result, "AssertSliceEqual result when not equal")
-	AssertTrue(t, mock.HasErrors(), "has errors on failure")
-	AssertFalse(t, mock.HasLogs(), "no logs on failure")
+	// Length is settled before the elements, and reported as a count.
+	mock.Reset()
+	assertFailed(t, mock, AssertSliceEqual(mock, S(1, 2, 3), S(1, 2),
+		"length test"), "expected 3 elements, got 2", "length")
+
+	// An empty glass and no glass are not the same: only nil equals nil.
+	// Both render as "[]", so the message names the nil-ness instead.
+	mock.Reset()
+	assertFailed(t, mock, AssertSliceEqual(mock, nil, S[int](),
+		"nil against empty test"), "expected nil slice, got empty slice",
+		"nil against empty")
+
+	mock.Reset()
+	assertFailed(t, mock, AssertSliceEqual(mock, S[int](), nil,
+		"empty against nil test"), "expected empty slice, got nil slice",
+		"empty against nil")
+
+	// Matched nil-ness passes on either side of that distinction, an
+	// empty slice having no elements to disagree over and nil being
+	// equal to the only thing it can be.
+	mock.Reset()
+	assertPassed(t, mock, AssertSliceEqual(mock, S[int](), S[int](),
+		"both empty test"), "both empty")
+
+	mock.Reset()
+	assertPassed(t, mock, AssertSliceEqual[int](mock, nil, nil,
+		"both nil test"), "both nil")
+
+	// AreEqual walks one level deep, so the inner slices are undecided.
+	// The message names the element type, the size being already settled.
+	mock.Reset()
+	assertFailed(t, mock, AssertSliceEqual(mock, S(S(1)), S(S(1)),
+		"undecided test"), "undecided for []int elements", "undecided")
+
+	// An undecided element ahead of the mismatch must not be mistaken
+	// for it: what settles the slice is the pair that differs, and that
+	// is the index worth reporting.
+	mock.Reset()
+	a, b := undecidedPair()
+	assertFailed(t, mock, AssertSliceEqual(mock, S[any](a, 1), S[any](b, 2),
+		"mixed test"), "index 1: expected 1, got 2", "mixed")
+}
+
+// TestSliceDiffErrorWithoutKnownDifference exercises the arm
+// AssertSliceEqual cannot reach: a slice it settles as unequal always
+// leaves an element known to differ for the walk to find. Called
+// directly with a pair that has none, doSliceDiffError must still
+// report — the assertion has already failed by then, and failing
+// without a message would be worse than naming the whole slice.
+func TestSliceDiffErrorWithoutKnownDifference(t *testing.T) {
+	mock := &MockT{}
+
+	doSliceDiffError(mock, S(1, 2), S(1, 2), "no known difference", nil)
+
+	lastErr, ok := mock.LastError()
+	AssertMustTrue(t, ok, "error reported")
+	AssertContains(t, lastErr, "expected [1 2], got [1 2]", "whole-slice message")
+}
+
+// Test AssertDeepEqual
+func TestAssertDeepEqual(t *testing.T) {
+	mock := &MockT{}
+
+	// Succeeds on a pair AssertEqual leaves undecided.
+	assertPassed(t, mock, AssertDeepEqual(mock, S(S(1)), S(S(1)),
+		"deep equal test"), "equal")
+
+	mock.Reset()
+	assertFailed(t, mock, AssertDeepEqual(mock, S(S(1)), S(S(2)),
+		"deep not equal test"), "expected [[1]], got [[2]]", "not equal")
+}
+
+// taggedValue is non-comparable — the slice sees to that — and its Equal
+// considers only the tag, so AreEqual and reflect.DeepEqual reach
+// different verdicts whenever the payloads differ.
+type taggedValue struct {
+	tag     string
+	payload []int
+}
+
+func (v taggedValue) Equal(o taggedValue) bool { return v.tag == o.tag }
+
+// TestEqualMethodVersusDeepEqual pins the divergence between the two
+// forms: AreEqual asks the type, reflect.DeepEqual never does. The deep
+// form is a fallback for what AreEqual cannot decide, not a stronger
+// version of it, and swapping one for the other can flip the verdict.
+func TestEqualMethodVersusDeepEqual(t *testing.T) {
+	mock := &MockT{}
+	a := taggedValue{payload: S(1), tag: "x"}
+	b := taggedValue{payload: S(2), tag: "x"}
+
+	assertPassed(t, mock, AssertEqual(mock, a, b, "Equal method test"),
+		"Equal method")
+
+	mock.Reset()
+	assertFailed(t, mock, AssertDeepEqual(mock, a, b, "deep test"),
+		"expected {x [1]}, got {x [2]}", "deep")
+}
+
+// Test AssertNotDeepEqual
+func TestAssertNotDeepEqual(t *testing.T) {
+	mock := &MockT{}
+
+	assertPassed(t, mock, AssertNotDeepEqual(mock, S(S(1)), S(S(2)),
+		"deep not equal test"), "not equal")
+
+	mock.Reset()
+	assertFailed(t, mock, AssertNotDeepEqual(mock, S(S(1)), S(S(1)),
+		"deep equal test"), "expected a different value, got [[1]]", "equal")
 }
 
 // Test AssertContains
@@ -1125,6 +1244,8 @@ func TestAssertMustFunctions(t *testing.T) {
 	t.Run("AssertMustEqual", testAssertMustEqual)
 	t.Run("AssertMustNotEqual", testAssertMustNotEqual)
 	t.Run("AssertMustSliceEqual", testAssertMustSliceEqual)
+	t.Run("AssertMustDeepEqual", testAssertMustDeepEqual)
+	t.Run("AssertMustNotDeepEqual", testAssertMustNotDeepEqual)
 	t.Run("AssertMustContains", testAssertMustContains)
 	t.Run("AssertMustNotContain", testAssertMustNotContain)
 	t.Run("AssertMustError", testAssertMustError)
@@ -1148,256 +1269,247 @@ func testAssertMustEqual(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case - should not call FailNow
 	ok := mock.Run("success", func(mt T) {
 		AssertMustEqual(mt, 42, 42, "equal values")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
-	AssertFalse(t, mock.Failed(), "Should not be marked as failed")
-	AssertEqual(t, 2, len(mock.Logs), "Should have logs from assertion and continuation")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case - should call FailNow and abort
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustEqual(mt, 42, 24, "different values")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 1, len(mock.Errors), "Should have error from failed assertion")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNotEqual(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNotEqual(mt, 42, 24, "different values")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNotEqual(mt, 42, 42, "equal values")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustSliceEqual(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustSliceEqual(mt, S(1, 2, 3), S(1, 2, 3), "equal slices")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustSliceEqual(mt, S(1, 2, 3), S(1, 2, 4), "different slices")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
+}
+
+func testAssertMustDeepEqual(t *testing.T) {
+	t.Helper()
+	mock := &MockT{}
+
+	ok := mock.Run("success", func(mt T) {
+		AssertMustDeepEqual(mt, S(S(1)), S(S(1)), "equal values")
+		mt.Log(mustContinuationLog)
+	})
+	assertMustContinued(t, mock, ok)
+
+	mock.Reset()
+
+	ok = mock.Run("failure", func(mt T) {
+		AssertMustDeepEqual(mt, S(S(1)), S(S(2)), "different values")
+		mt.Log("should not reach here")
+	})
+	assertMustAborted(t, mock, ok)
+}
+
+func testAssertMustNotDeepEqual(t *testing.T) {
+	t.Helper()
+	mock := &MockT{}
+
+	ok := mock.Run("success", func(mt T) {
+		AssertMustNotDeepEqual(mt, S(S(1)), S(S(2)), "different values")
+		mt.Log(mustContinuationLog)
+	})
+	assertMustContinued(t, mock, ok)
+
+	mock.Reset()
+
+	ok = mock.Run("failure", func(mt T) {
+		AssertMustNotDeepEqual(mt, S(S(1)), S(S(1)), "equal values")
+		mt.Log("should not reach here")
+	})
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustContains(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustContains(mt, "hello world", "world", "contains substring")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustContains(mt, "hello world", "xyz", "missing substring")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNotContain(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case (substring not present)
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNotContain(mt, "hello world", "xyz", "no substring")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case (substring present)
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNotContain(mt, "hello world", "world", "has substring")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustError(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustError(mt, errors.New("test error"), "expects error")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustError(mt, nil, "expects error but got nil")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNoError(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNoError(mt, nil, "expects no error")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNoError(mt, errors.New("unexpected error"), "expects no error")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustPanic(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustPanic(mt, func() { panic("test panic") }, nil, "expects panic")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustPanic(mt, func() {}, nil, "expects panic but got none")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNoPanic(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNoPanic(mt, func() {}, "expects no panic")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNoPanic(mt, func() { panic("unexpected") }, "expects no panic")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustTrue(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustTrue(mt, true, "expects true")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustTrue(mt, false, "expects true but got false")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustFalse(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustFalse(mt, false, "expects false")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustFalse(mt, true, "expects false but got true")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustErrorIs(t *testing.T) {
@@ -1406,24 +1518,20 @@ func testAssertMustErrorIs(t *testing.T) {
 	baseErr := errors.New("base error")
 	wrappedErr := errors.Join(baseErr, errors.New("wrapped"))
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustErrorIs(mt, wrappedErr, baseErr, "error should match")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	otherErr := errors.New("other error")
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustErrorIs(mt, wrappedErr, otherErr, "error should not match")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNotErrorIs(t *testing.T) {
@@ -1432,24 +1540,20 @@ func testAssertMustNotErrorIs(t *testing.T) {
 	baseErr := errors.New("base error")
 	wrappedErr := errors.Join(baseErr, errors.New("wrapped"))
 
-	// Test success case
 	otherErr := errors.New("other error")
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNotErrorIs(mt, wrappedErr, otherErr, "error should not match")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNotErrorIs(mt, wrappedErr, baseErr, "error should match")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustErrorIsFn(t *testing.T) {
@@ -1459,23 +1563,19 @@ func testAssertMustErrorIsFn(t *testing.T) {
 	wrappedErr := Wrap(baseErr, "wrapped")
 	isBase := func(err error) bool { return err == baseErr }
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustErrorIsFn(mt, wrappedErr, isBase, "error should match")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustErrorIsFn(mt, errors.New("other error"), isBase, "error should not match")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustErrorAs(t *testing.T) {
@@ -1483,98 +1583,80 @@ func testAssertMustErrorAs(t *testing.T) {
 	mock := &MockT{}
 	wrapped := Wrap(errors.New("base error"), "note")
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		out := AssertMustErrorAs[*WrappedError](mt, wrapped, "type should match")
 		AssertSame(mt, wrapped, *out, "matched value")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustErrorAs[*WrappedError](mt, errors.New("plain"), "type should not match")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustTypeIs(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		var val any = "hello"
 		result := AssertMustTypeIs[string](mt, val, "type should match")
-		mt.Log("execution continues")
 		AssertEqual(mt, "hello", result, "should return cast value")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		var val any = 42
-		result := AssertMustTypeIs[string](mt, val, "type should not match")
+		AssertMustTypeIs[string](mt, val, "type should not match")
 		mt.Log("should not reach here")
-		// result should be zero value but we shouldn't reach here
-		_ = result
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNil(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNil(mt, nil, "expects nil")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNil(mt, "not nil", "expects nil but got value")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNotNil(t *testing.T) {
 	t.Helper()
 	mock := &MockT{}
 
-	// Test success case
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNotNil(mt, "not nil", "expects not nil")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNotNil(mt, nil, "expects not nil but got nil")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustSame(t *testing.T) {
@@ -1584,24 +1666,20 @@ func testAssertMustSame(t *testing.T) {
 	slice1 := []int{1, 2, 3}
 	slice2 := slice1 // Same reference
 
-	// Test success case - same reference
 	ok := mock.Run("success", func(mt T) {
 		AssertMustSame(mt, slice1, slice2, "same slice reference")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case - different references
 	slice3 := []int{1, 2, 3} // Different reference
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustSame(mt, slice1, slice3, "different slice references")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 func testAssertMustNotSame(t *testing.T) {
@@ -1611,24 +1689,20 @@ func testAssertMustNotSame(t *testing.T) {
 	slice1 := []int{1, 2, 3}
 	slice3 := []int{1, 2, 3} // Different reference
 
-	// Test success case - different references
 	ok := mock.Run("success", func(mt T) {
 		AssertMustNotSame(mt, slice1, slice3, "different slice references")
-		mt.Log("execution continues")
+		mt.Log(mustContinuationLog)
 	})
-	AssertTrue(t, ok, "Success case should not abort")
+	assertMustContinued(t, mock, ok)
 
 	mock.Reset()
 
-	// Test failure case - same reference
 	slice2 := slice1 // Same reference
 	ok = mock.Run("failure", func(mt T) {
 		AssertMustNotSame(mt, slice1, slice2, "same slice reference")
 		mt.Log("should not reach here")
 	})
-	AssertFalse(t, ok, "Failure case should abort")
-	AssertTrue(t, mock.Failed(), "Should be marked as failed")
-	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+	assertMustAborted(t, mock, ok)
 }
 
 // assertErrorContains checks that the last error from MockT contains the expected substring
@@ -1637,4 +1711,51 @@ func assertErrorContains(t *testing.T, mock *MockT, expected, desc string) {
 	lastErr, ok := mock.LastError()
 	AssertTrue(t, ok, "LastError ok for "+desc)
 	AssertTrue(t, strings.Contains(lastErr, expected), desc)
+}
+
+// assertMustContinued checks that a Must assertion passed and let the
+// caller carry on. The continuation log is matched rather than counted,
+// so a case that asserts on a returned value in between still fits.
+func assertMustContinued(t *testing.T, mock *MockT, ok bool) {
+	t.Helper()
+	AssertTrue(t, ok, "Success case should not abort")
+	AssertFalse(t, mock.Failed(), "Should not be marked as failed")
+	AssertFalse(t, mock.HasErrors(), "Should have no errors")
+
+	lastLog, hasLog := mock.LastLog()
+	AssertTrue(t, hasLog, "Should have logged the assertion")
+	AssertEqual(t, mustContinuationLog, lastLog, "Should reach continuation log")
+}
+
+// mustContinuationLog is what every Must success case logs after the
+// assertion, marking that execution was not cut short.
+const mustContinuationLog = "execution continues"
+
+// assertMustAborted checks that a Must assertion failed and cut the
+// caller short before its continuation ran.
+func assertMustAborted(t *testing.T, mock *MockT, ok bool) {
+	t.Helper()
+	AssertFalse(t, ok, "Failure case should abort")
+	AssertTrue(t, mock.Failed(), "Should be marked as failed")
+	AssertEqual(t, 1, len(mock.Errors), "Should have error from failed assertion")
+	AssertEqual(t, 0, len(mock.Logs), "Should not reach continuation log")
+}
+
+// assertPassed checks that an assertion reported success: it returned
+// true, logged the value, and recorded no error.
+func assertPassed(t *testing.T, mock *MockT, result bool, desc string) {
+	t.Helper()
+	AssertTrue(t, result, "%s result", desc)
+	AssertFalse(t, mock.HasErrors(), "%s errors", desc)
+	AssertTrue(t, mock.HasLogs(), "%s logs", desc)
+}
+
+// assertFailed checks that an assertion reported failure: it returned
+// false, recorded an error containing expected, and logged nothing.
+func assertFailed(t *testing.T, mock *MockT, result bool, expected, desc string) {
+	t.Helper()
+	AssertFalse(t, result, "%s result", desc)
+	AssertTrue(t, mock.HasErrors(), "%s errors", desc)
+	AssertFalse(t, mock.HasLogs(), "%s logs", desc)
+	assertErrorContains(t, mock, expected, desc+" message")
 }

--- a/zero_test.go
+++ b/zero_test.go
@@ -1737,3 +1737,50 @@ func TestAreEqual(t *testing.T) {
 		RunTestCases(t, areEqualSliceTestCases())
 	})
 }
+
+// Benchmarks
+//
+// AreEqual buys its panic-free breadth with reflection, and these measure
+// what that costs against a plain ==. They exist to document the gap, not
+// to be closed: the Assert family that calls AreEqual runs in tests, where
+// a decisive answer and a useful message beat nanoseconds.
+
+// benchEqualSink keeps the compiler from eliding the comparisons below.
+var benchEqualSink bool
+
+func BenchmarkEqualOperator(b *testing.B) {
+	x, y := 42, 42
+	for b.Loop() {
+		benchEqualSink = x == y
+	}
+}
+
+func BenchmarkAreEqualComparable(b *testing.B) {
+	x, y := 42, 42
+	for b.Loop() {
+		benchEqualSink, _ = AreEqual(x, y)
+	}
+}
+
+func BenchmarkAreEqualMethod(b *testing.B) {
+	x, y := eqSlice{1, 2, 3}, eqSlice{1, 2, 3}
+	for b.Loop() {
+		benchEqualSink, _ = AreEqual(x, y)
+	}
+}
+
+func BenchmarkAreEqualSlice(b *testing.B) {
+	x, y := S(1, 2, 3), S(1, 2, 3)
+	for b.Loop() {
+		benchEqualSink, _ = AreEqual(x, y)
+	}
+}
+
+// BenchmarkAreEqualUndecided measures the walk that ends in no answer,
+// the path Assert functions turn into a failure.
+func BenchmarkAreEqualUndecided(b *testing.B) {
+	x, y := map[string]int{"a": 1}, map[string]int{"a": 1}
+	for b.Loop() {
+		benchEqualSink, _ = AreEqual(x, y)
+	}
+}


### PR DESCRIPTION
`AssertEqual` and `AssertNotEqual` were constrained to `comparable`, so a
slice, a map, or a type carrying an `Equal(T) bool` method could not be
asserted on at all — the compiler rejected the call. They now delegate to
`AreEqual`, which settles typed nils, identity, an `Equal` method, and
slices one level deep without panicking.

`AssertDeepEqual` and `AssertNotDeepEqual`, with their `Must` forms, settle
what `AreEqual` cannot decide — `AssertNotEqual` reading `known` before `is`
so unknown is not taken for a difference, pinned by a permanent row. The
failure says a deep comparison is what the pair needs, and stops short of
naming the function: a base assertion cannot tell whether its caller came
through a `Must` wrapper, and sending a `Must` caller to `AssertDeepEqual`
would trade their abort away silently.

The deep form is a fallback, not a stronger one. `reflect.DeepEqual` never
asks the type, so a lenient `Equal` method passes `AssertEqual` and fails
`AssertDeepEqual` — and a slice falling back withdraws that treatment from
its elements too. Worth knowing before taking the advice the failure gives.
A permanent row pins the divergence.

## Behavioural change for `AssertSliceEqual`

Two things in this PR can break a build which currently passes: this, and the
reworded negative failures further down.

`AssertSliceEqual` moves from `reflect.DeepEqual` to `AreEqual`. Callers
passing nested or otherwise non-comparable elements now fail as undecided
where `reflect.DeepEqual` used to answer silently. The failure says the pair
needs a deep comparison; the fix per call site is `AssertDeepEqual`, or
`AssertMustDeepEqual` where the assertion should abort.

It also gains messages that report the mismatch actually found: a length
difference as a count, nil-versus-empty by name — both otherwise print as an
indistinguishable `[]`, and only nil equals nil — and otherwise the first
element known to differ, by index, rather than two whole slices to compare by
eye. The index cited is the one that settled the slice: an element `AreEqual`
cannot judge fails the assertion as undecided when it stands alone, so reaching
the diff at all means something else decided the verdict.

## Also here

The negative failures read "expected not X, got X", stating the same value
twice because equality is why they fired. They now follow the house pattern
set by `AssertNotSame`. Downstream tests that match on the message text see it
change — that is the second breakage flagged above.

The docs follow the code: `README.md` gains the new entries and a note on what
`AreEqual` decides, `TESTING.md` a section on choosing between the `Equal` and
`DeepEqual` families, and `TESTING_core.md` a corrected hierarchy.

`AreEqual` is benchmarked against `==` while here. It costs roughly 67 times
a comparison on the comparable path, plus two allocations from boxing. That
is the price of the breadth above and not a target: these run in tests, where
a decisive answer and a message worth reading beat nanoseconds.

The `Must` tests are folded onto shared helpers. They asserted less than they
appeared to — most checked only that the assertion did not abort — and each
now checks the failure marker, the error, and whether the continuation ran.

"docs: close two BUILDING.md gaps left by the vet and Platforms work" rides
along: it is two lines and the same review.

## Verification

`make all`, `make race` and `make coverage` green, full repo; coverage 99.8%.
The remaining uncovered blocks are pre-existing and environment-dependent
(`Here`, `GetInterfacesNames`, `GetIPAddresses`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep equality and inequality assertions, including fatal variants.
  * Equality assertions now support non-comparable values and provide clearer slice mismatch details, including length and nil-versus-empty differences.
  * Expanded configurable testing flags for dependency updates and vetting.

* **Documentation**
  * Updated assertion guidance, API references, and CI/CD documentation to describe the new comparison behaviour and cross-platform testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->