### PR TITLE
fix: honour Equal when == calls a comparable pair unequal

### DIFF
--- a/as.go
+++ b/as.go
@@ -76,7 +76,7 @@ func AsError[T any](v T) error {
 // the elements that are errors.
 func AsErrors[T any](vv []T) []error {
 	return SliceAsFn(func(v T) (error, bool) {
-		err := AsError[T](v)
+		err := AsError(v)
 		return err, err != nil
 	}, vv)
 }

--- a/zero.go
+++ b/zero.go
@@ -398,13 +398,20 @@ func isComparableValue(v reflect.Value) bool {
 	return !v.IsValid() || v.Comparable()
 }
 
-// AreEqual reports whether every given value equals the next one, as
-// the == operator would decide, without ever panicking. Values of the
-// same comparable type are tested with == itself. When == is
-// unavailable, typed nils and identity — sharing the same underlying
-// data, as [IsSame] sees it — settle the question, and the value's
-// own Equal method, following the Equal(T) bool convention, stands in
-// for ==.
+// AreEqual reports whether every given value equals the next one,
+// without ever panicking. Values of the same comparable type are tested
+// with == first: a true == is authoritative, and a false == defers to
+// the value's own Equal method, following the Equal(T) bool convention.
+// A comparable type whose == tests more than its own notion of equality
+// still settles correctly this way:
+//   - time.Time compares its monotonic reading under ==, its instant
+//     under Equal.
+//   - a pointer type that defines Equal compares identity under ==, its
+//     contents under Equal.
+//
+// When == is unavailable, the question is settled by typed nils, by
+// identity (the same underlying data, as [IsSame] sees it), and by the
+// Equal method standing in for ==.
 //
 // Slices without a decisive Equal method are compared element by
 // element, one level deep: lengths must match, and each element pair
@@ -468,11 +475,31 @@ func areEqual2(a, b comparableValue, deep bool) (is, known bool) {
 		// both untyped nil
 		return true, true
 	case a.ok && b.ok:
-		// safe ==
-		return a.v.Interface() == b.v.Interface(), true
+		// == decides; a false == still defers to an Equal method
+		return areEqualComparable(a.v, b.v)
 	default:
 		return areEqualFallback(a.v, b.v, deep)
 	}
+}
+
+// areEqualComparable settles two operands that both support ==. A true
+// == is authoritative and skips the Equal method. A false == defers to
+// the Equal method, following the Equal(T) bool convention, so a type
+// whose == tests more than its own notion of equality still settles
+// correctly. Without a decisive Equal method, == stands.
+func areEqualComparable(va, vb reflect.Value) (is, known bool) {
+	if va.Interface() == vb.Interface() {
+		// authoritative
+		return true, true
+	}
+
+	if is, known = equalMethod(va, vb); known {
+		// Equal rescues a pair == calls unequal
+		return is, true
+	}
+
+	// == is authoritative when no Equal method decides
+	return false, true
 }
 
 // areEqualFallback decides equality when == is unavailable: typed
@@ -564,7 +591,8 @@ func unwrapInterface(v reflect.Value) reflect.Value {
 }
 
 // equalMethod consults the value's own Equal method, following the
-// Equal(T) bool convention, as a stand-in for an unavailable ==.
+// Equal(T) bool convention, to decide a pair == cannot settle, whether
+// because == is unavailable or because it called the pair unequal.
 // Without such a method, or if the call panics, the question stays
 // unknown.
 func equalMethod(va, vb reflect.Value) (is, known bool) {

--- a/zero_test.go
+++ b/zero_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unsafe"
@@ -1544,10 +1545,22 @@ type panicEqMap map[string]int
 func (panicEqMap) Equal(panicEqMap) bool { panic("Equal called") }
 
 // eqAlways is comparable with an Equal method that always matches,
-// proving == takes precedence for comparable types.
+// proving a false == defers to Equal for comparable types.
 type eqAlways int
 
 func (eqAlways) Equal(eqAlways) bool { return true }
+
+// eqNeverComparable is comparable with an Equal method that never
+// matches. The call counter lets a test prove a true == skips Equal
+// outright while a false == still invokes it.
+type eqNeverComparable int
+
+var eqNeverComparableCalls atomic.Int64
+
+func (eqNeverComparable) Equal(eqNeverComparable) bool {
+	eqNeverComparableCalls.Add(1)
+	return false
+}
 
 type areComparableTestCase struct {
 	name string
@@ -1636,8 +1649,12 @@ func areEqualComparableTestCases() []areEqualTestCase {
 			S[any]("a", "a", "b"), false, true),
 		newAreEqualTestCase("NaN never equals",
 			S[any](math.NaN(), math.NaN()), false, true),
-		newAreEqualTestCase("== beats Equal for comparable types",
-			S[any](eqAlways(1), eqAlways(2)), false, true),
+		newAreEqualTestCase("Equal rescues a false ==",
+			S[any](eqAlways(1), eqAlways(2)), true, true),
+		newAreEqualTestCase("true == skips Equal",
+			S[any](eqNeverComparable(1), eqNeverComparable(1)), true, true),
+		newAreEqualTestCase("false == with false Equal stays unequal",
+			S[any](eqNeverComparable(1), eqNeverComparable(2)), false, true),
 	}
 }
 
@@ -1736,6 +1753,22 @@ func TestAreEqual(t *testing.T) {
 	t.Run("slices", func(t *testing.T) {
 		RunTestCases(t, areEqualSliceTestCases())
 	})
+}
+
+// TestAreEqualComparableEqualCalls pins that AreEqual consults a
+// comparable type's Equal method only when == is false: a true == skips
+// it outright, a false == invokes it. The table rows above cover the
+// returned verdict; this covers the call itself.
+func TestAreEqualComparableEqualCalls(t *testing.T) {
+	eqNeverComparableCalls.Store(0)
+	is, _ := AreEqual(eqNeverComparable(1), eqNeverComparable(1))
+	AssertTrue(t, is, "true == equal")
+	AssertEqual(t, int64(0), eqNeverComparableCalls.Load(), "Equal skipped on true ==")
+
+	eqNeverComparableCalls.Store(0)
+	is, _ = AreEqual(eqNeverComparable(1), eqNeverComparable(2))
+	AssertFalse(t, is, "false == unequal")
+	AssertEqual(t, int64(1), eqNeverComparableCalls.Load(), "Equal consulted on false ==")
 }
 
 // Benchmarks


### PR DESCRIPTION
## Summary

Fixes a regression shipped in **v0.21.0**: `AssertEqual` — and with it
`AssertNotEqual` and `AssertSliceEqual` — began failing on comparable
types whose `==` inspects more than the type's own notion of equality.
Two equal instants of `time.Time`, or two `*x509.Certificate` /
`*big.Int` pointers with identical contents behind distinct addresses,
wrongly compared unequal. This made v0.21.0 unusable for that class of
type.

## Background

v0.21.0's **feat: decide Assert equality with AreEqual** routed the
assertion family through `AreEqual`, which tested same-type comparable
operands with `==` alone. When a type's `==` sees representation the
type doesn't count as identity — `time.Time`'s monotonic reading, a
pointer's address — that comparison rejects values the type itself
considers equal. A type's `Equal` method exists precisely to answer the
comparisons where `==` overreaches; ignoring it for comparable types is
the regression.

## Change

Comparable operands now test `==` first and fall through to the `Equal`
method on inequality:

- a true `==` is authoritative and skips `Equal` — every field matched,
  so there is nothing non-evident for `Equal` to correct;
- a false `==` defers to the value's `Equal(T) bool` method;
- `==` stands when no such method decides.

This reverses only the precedence the earlier work pinned, where `==`
won outright for comparable types. The non-comparable path is unchanged
— it already consulted `Equal` through `areEqualFallback`.

## Tests

- The `eqAlways` fixture and its row now assert that `Equal` rescues a
  false `==`.
- A new `eqNeverComparable` fixture pins that a true `==` still skips
  `Equal`, and that a false `==` with a false `Equal` stays unequal.

## Also in this branch

- **refactor: drop the inferable type argument on the AsError call** —
  `AsErrors` lets `AsError`'s type parameter infer from its argument
  rather than spelling out `AsError[T](v)`.

Lands as **v0.21.1**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `AreEqual` handling for comparable values that also define an `Equal` method.
  * Direct comparison (`==`) is now authoritative when it reports equality.
  * When `==` reports inequality, the custom `Equal` method is consulted (or the values settle as unequal when no decisive result is available).

* **Tests**
  * Added coverage for `AreEqual` behaviour with comparable custom-equality types, including assertions about when `Equal` is (and isn’t) called.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->