### PR TITLE
revert: return error sentinels to identity matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,17 +256,14 @@ Key distinctions from `IsZero`:
 
 ## Error Handling
 
-### Standard Error Sentinels
+### Standard Error Variables
 
-Predefined errors for common conditions. All are `StringError` constants
-except `ErrTODO` (a wrapped error) and `ErrInvalid` (an alias of
-`fs.ErrInvalid`):
+Predefined error values for common conditions:
 
 * `ErrNotImplemented` - functionality not yet implemented.
 * `ErrTODO` - placeholder for future implementation.
-* `ErrExists` - resource already exists (distinct from `fs.ErrExist`).
-* `ErrNotExists` - resource does not exist (distinct from
-  `fs.ErrNotExist`).
+* `ErrExists` - resource already exists.
+* `ErrNotExists` - resource does not exist.
 * `ErrInvalid` - invalid input or state.
 * `ErrUnknown` - unknown or unspecified error.
 * `ErrNilReceiver` - method called on nil receiver.

--- a/addrs_test.go
+++ b/addrs_test.go
@@ -123,17 +123,12 @@ func (tc parseNetIPTestCase) Test(t *testing.T) {
 
 	got, err := ParseNetIP(tc.input)
 	if tc.wantErr {
-		if err == nil {
-			t.Error("Expected error but got nil")
-		}
-	} else {
-		if err != nil {
-			t.Errorf("Expected no error but got: %v", err)
-		}
-		if !got.Equal(tc.want) {
-			t.Errorf("Expected %v, got %v", tc.want, got)
-		}
+		AssertError(t, err, "error")
+		return
 	}
+
+	AssertNoError(t, err, "parse")
+	AssertEqual(t, tc.want, got, "IP")
 }
 
 func TestParseNetIP(t *testing.T) {
@@ -451,15 +446,11 @@ func TestAsNetIPAddresses(t *testing.T) {
 	result := asNetIPAddresses(addrs...)
 
 	// Should have 3 valid addresses (invalid one skipped)
-	if len(result) != 3 {
-		t.Errorf("Expected 3 addresses, got %d", len(result))
-	}
+	AssertMustEqual(t, 3, len(result), "count")
 
 	// Verify the IPv4-mapped address is unmapped
 	lastAddr := result[2]
-	if !lastAddr.Equal(net.ParseIP("192.168.1.2")) {
-		t.Errorf("Expected unmapped IPv4 address, got %v", lastAddr)
-	}
+	AssertEqual(t, net.ParseIP("192.168.1.2"), lastAddr, "unmapped IPv4")
 }
 
 func TestAsNetIP(t *testing.T) {
@@ -472,13 +463,9 @@ func testAsNetIPv4(t *testing.T) {
 	addr := netip.MustParseAddr("192.168.1.1")
 	ip := asNetIP(addr)
 	expected := net.ParseIP("192.168.1.1").To4()
-	if !ip.Equal(expected) {
-		t.Errorf("Expected %v, got %v", expected, ip)
-	}
+	AssertEqual(t, expected, ip, "IPv4")
 	// Should be 4 bytes for IPv4
-	if len(ip) != 4 {
-		t.Errorf("Expected 4 bytes for IPv4, got %d", len(ip))
-	}
+	AssertEqual(t, 4, len(ip), "byte length")
 }
 
 func testAsNetIPv6(t *testing.T) {
@@ -486,13 +473,9 @@ func testAsNetIPv6(t *testing.T) {
 	addr := netip.MustParseAddr("2001:db8::1")
 	ip := asNetIP(addr)
 	expected := net.ParseIP("2001:db8::1")
-	if !ip.Equal(expected) {
-		t.Errorf("Expected %v, got %v", expected, ip)
-	}
+	AssertEqual(t, expected, ip, "IPv6")
 	// Should be 16 bytes for IPv6
-	if len(ip) != 16 {
-		t.Errorf("Expected 16 bytes for IPv6, got %d", len(ip))
-	}
+	AssertEqual(t, 16, len(ip), "byte length")
 }
 
 func TestAppendNetIPAsIP(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -1,38 +1,31 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"slices"
 )
 
-// Sentinel errors for common conditions. Except for [ErrTODO] and
-// [ErrInvalid], these are [StringError] constants: they can't be
-// reassigned and match by value.
-const (
-	// ErrNotImplemented indicates something hasn't been implemented yet
-	ErrNotImplemented StringError = "not implemented"
-	// ErrExists indicates something already exists. It is deliberately
-	// general, distinct from the file-centric [fs.ErrExist].
-	ErrExists StringError = "already exists"
-	// ErrNotExists indicates something doesn't exist. It is deliberately
-	// general, distinct from the file-centric [fs.ErrNotExist].
-	ErrNotExists StringError = "does not exist"
-	// ErrUnknown indicates something isn't recognized
-	ErrUnknown StringError = "unknown"
-	// ErrNilReceiver indicates a method was called over a nil instance
-	ErrNilReceiver StringError = "nil receiver"
-	// ErrUnreachable indicates something impossible happened
-	ErrUnreachable StringError = "unreachable"
-)
-
 var (
+	// ErrNotImplemented indicates something hasn't been implemented yet
+	ErrNotImplemented = errors.New("not implemented")
 	// ErrTODO is like ErrNotImplemented but used especially to
 	// indicate something needs to be implemented
 	ErrTODO = Wrap(ErrNotImplemented, "TODO")
+	// ErrExists indicates something already exists
+	ErrExists = errors.New("already exists")
+	// ErrNotExists indicates something doesn't exist
+	ErrNotExists = errors.New("does not exist")
 	// ErrInvalid indicates an argument isn't valid. It's an alias of
 	// [fs.ErrInvalid] so errors.Is matches across the boundary.
 	ErrInvalid = fs.ErrInvalid
+	// ErrUnknown indicates something isn't recognized
+	ErrUnknown = errors.New("unknown")
+	// ErrNilReceiver indicates a method was called over a nil instance
+	ErrNilReceiver = errors.New("nil receiver")
+	// ErrUnreachable indicates something impossible happened
+	ErrUnreachable = errors.New("unreachable")
 )
 
 var (


### PR DESCRIPTION
## Summary

Returns the six leaf error sentinels to identity matching, and migrates
the `net.IP` equality checks in `addrs_test.go` onto `AssertEqual`.

## Sentinels back to identity

`refactor: make error sentinels StringError constants` turned
`ErrNotImplemented`, `ErrExists`, `ErrNotExists`, `ErrUnknown`,
`ErrNilReceiver` and `ErrUnreachable` into `StringError` constants. As
constants they match by value, so any `StringError` carrying the same
text — including one declared in a downstream package — satisfied
`errors.Is` against a core sentinel, with no compile error or failing
test to flag it.

For package sentinels identity is the safer default: each value matches
only itself. This backs that change out; the sentinels are `errors.New`
values again. The `StringError` type stays available for callers who want
a constant-capable error explicitly.

`ErrTODO` and `ErrInvalid` are unaffected — they were already vars.

## net.IP equality through AssertEqual

`net.IP` is a `[]byte` type carrying an `Equal(net.IP) bool` method, and
`AreEqual` reaches that method before it would walk the slice. The
hand-written `got.Equal(want)` checks in the `ParseNetIP` and `asNetIP`
tests now go through `AssertEqual`, which honours it.

The `result[2]` index in `TestAsNetIPAddresses` gains an `AssertMustEqual`
length precondition, so a short slice aborts at the check rather than
panicking on the index. The byte-length assertions stay: `Equal` treats a
4-byte and a 16-byte form as equal, so only the explicit length pins the
unmapping.

## API note

The sentinels' exported type reverts from `StringError` to `error`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Standard error values are now provided as assignable variables rather than constants.
  * Existing predefined errors remain available, including not implemented, already exists, does not exist, unknown, nil receiver, unreachable and invalid errors.
  * `ErrTODO` continues to represent an unimplemented operation while wrapping the standard not-implemented error.

* **Documentation**
  * Updated the error reference section to describe standard error variables and their available names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->