### PR TITLE
build: make the native tidy check portable and run it on the platform runners

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalise every text file to LF in the repository and on checkout, so
+# the platform runners (Windows included) match .editorconfig and make
+# tidy does not report a line-ending diff.
+* text=auto eol=lf

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -109,6 +109,16 @@ jobs:
       run: brew install coreutils findutils gnu-sed grep
     - name: Run tests
       run: make test ${{ matrix.make_args }}
+    # Reuse the test boxes rather than spend runners on a tidy job. The
+    # linter version is selected per Go version, so run tidy on every
+    # cell: each tier enforces its own rules, and the versions diverge
+    # again over time. This also lints the darwin/windows loader files
+    # golangci-lint skips off-platform. git diff --exit-code then fails,
+    # printing the patch, on any change.
+    - name: Tidy leaves no changes
+      run: |
+        make tidy ${{ matrix.make_args }}
+        git diff --exit-code
 
   race:
     name: race (${{ matrix.os }})

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ FIX_WHITESPACE_EXCLUDE_EXTS ?= \
 	$(FIX_WHITESPACE_EXCLUDE_OTHER_EXTS)
 FIX_WHITESPACE_EXCLUDE_PATTERNS ?= $(patsubst %,-o -name '*.%',$(FIX_WHITESPACE_EXCLUDE_EXTS))
 FIX_WHITESPACE_EXCLUDE ?= $(FIX_WHITESPACE_EXCLUDE_GO) $(FIX_WHITESPACE_EXCLUDE_PATTERNS)
-FIX_WHITESPACE_ARGS ?= . \! \( $(FIX_WHITESPACE_EXCLUDE) \)
+FIX_WHITESPACE_ARGS ?= . '!' '(' $(FIX_WHITESPACE_EXCLUDE) ')'
 
 ifndef DLX
 ifeq ($(shell pnpm --version < /dev/null 2> /dev/null | grep -q '^[0-9]' && echo yes),yes)
@@ -73,7 +73,8 @@ DLX = true
 endif
 endif
 
-FIND_FILES_PRUNE_RULES ?= -name vendor -o -name .git -o -name node_modules -o -name .tmp -o -name .srclight -o -name .claude
+FIND_FILES_PRUNE_RULES ?= -name vendor -o -name .git -o -name node_modules \
+			  -o -name .tmp -o -name .srclight -o -name .claude
 FIND_FILES_PRUNE_ARGS ?= \( $(FIND_FILES_PRUNE_RULES) \) -prune
 FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'
 
 ifndef MARKDOWNLINT
-ifeq ($(shell $(DLX) markdownlint-cli --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
-MARKDOWNLINT = $(DLX) markdownlint-cli
+ifeq ($(shell $(DLX) markdownlint-cli2 --help < /dev/null | grep -q '^markdownlint-cli2 v[0-9]' && echo yes),yes)
+MARKDOWNLINT = $(DLX) markdownlint-cli2
 else
 MARKDOWNLINT = true
 endif

--- a/internal/build/fix_whitespace.sh
+++ b/internal/build/fix_whitespace.sh
@@ -23,6 +23,16 @@ set -eu
 JOBS="${JOBS:-4}"
 FILES_PER_JOB="${FILES_PER_JOB:-4}"
 
+# stat_mode FILE — output FILE's permission bits in octal.
+# There is no POSIX stat(1), so probe once for the GNU (-c) dialect and
+# fall back to BSD (-f); the two are mutually incompatible. GNU covers
+# Linux and the MSYS coreutils on the Windows runner, BSD covers macOS.
+if stat -c '%a' . >/dev/null 2>&1; then
+	stat_mode() { stat -c '%a' "$1"; }
+else
+	stat_mode() { stat -f '%Lp' "$1"; }
+fi
+
 # get_bytes FILE COUNT
 # COUNT > 0: first COUNT bytes (head)
 # COUNT < 0: last -COUNT bytes (tail)
@@ -47,12 +57,17 @@ quote_arg() {
 # filter_file FILE COMMAND [ARGS...]
 # Applies filter command to file in-place, preserving permissions
 filter_file() {
-	local file="$1" tmp
+	local file="$1" tmp mode
 	shift
 
 	tmp=$(mktemp "fix_whitespace.XXXXXX")
+	# mktemp yields a writable temp; restore the original's mode onto it
+	# after the write, then rename. chmod --reference would do this in one
+	# step but is GNU-only, so read the mode with the portable stat_mode
+	# probe above.
+	mode=$(stat_mode "$file")
 	if "$@" < "$file" > "$tmp"; then
-		chmod --reference="$file" "$tmp"
+		chmod "$mode" "$tmp"
 		mv "$tmp" "$file"
 	else
 		rm -f "$tmp"
@@ -112,9 +127,9 @@ run_find() {
 	done
 
 	# Wrap user conditions in parentheses if they exist
-	[ $# -eq 0 ] || set -- \( "$@" \)
+	[ $# -eq 0 ] || set -- '(' "$@" ')'
 	# combine auto-pruning and user conditions
-	set -- \( -type d \( -name .git -o -name .tmp -o -name node_modules -o -name .srclight -o -name .claude \) \) -prune -o "$@" -type f
+	set -- '(' -type d '(' -name .git -o -name .tmp -o -name node_modules -o -name .srclight -o -name .claude ')' ')' -prune -o "$@" -type f
 	# combine escaped paths with find options
 	eval "set -- ${paths:-.} \"\$@\""
 

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -75,6 +75,18 @@ gen_var_name() {
 	done
 }
 
+# align renders the tab-separated "NAME<TAB>=<TAB>value" rows as a table.
+# column(1) is absent from some minimal and Windows shells; there we fall
+# back to tr, turning the tab delimiters into spaces — the result loses the
+# alignment but is still valid Make.
+align() {
+	if command -v "$COLUMN" >/dev/null 2>&1; then
+		"$COLUMN" -t -s "$TAB"
+	else
+		"$TR" "$TAB" ' '
+	fi
+}
+
 # generate files lists
 #
 gen_files_lists() {
@@ -109,7 +121,7 @@ EOT
 		cat <<-EOT
 		$files$TAB=$TAB$files_cmd
 		EOT
-	done < "$INDEX" | "$COLUMN" -t -s "$TAB"
+	done < "$INDEX" | align
 }
 
 gen_make_targets() {

--- a/internal/build/get_version.sh
+++ b/internal/build/get_version.sh
@@ -7,7 +7,7 @@ xy_ver() {
 	local ver="${1:-}"
 	local x y
 
-	if echo "v${ver}" | grep -qe '^v[0-9]\+\.[0-9]\+\(\..*\|$\)'; then
+	if echo "v${ver}" | grep -Eq '^v[0-9]+\.[0-9]+(\..*|$)'; then
 		x="$(echo "$ver" | cut -d. -f1)"
 		y="$(echo "$ver" | cut -d. -f2)"
 		echo $((x * 1000 + y))
@@ -17,7 +17,7 @@ xy_ver() {
 	fi
 }
 
-GO_VERSION=$(${GO:-go} version | sed -ne 's|.* go\([0-9][^ ]\+\)[ $].*|\1|p')
+GO_VERSION=$(${GO:-go} version | sed -ne 's|.* go\([0-9][^ ]\{1,\}\)[ $].*|\1|p')
 
 if [ $# -eq 0 ]; then
 	# no arguments, go version


### PR DESCRIPTION
## Summary

Imports the build-system portability work merged in darvaza.org/x
(darvaza-proxy/x#317), keeping the shared build infrastructure
byte-identical across repos: a natively portable `make tidy`, the
markdownlint-cli2 upgrade, and a CI step running tidy on the platform
runners.

## Portable native tidy

`fix(build): make the native tidy check portable on macOS and Windows`
removes the GNU-isms that never bit on Linux:

- `chmod --reference` is GNU-only; `fix_whitespace.sh` now probes once
  for the GNU (`-c`) or BSD (`-f`) `stat` dialect, reads the original
  file's mode, and reapplies it with plain `chmod`.
- The find operators were backslash-escaped (`\!`, `\(`, `\)`); on the
  Windows runner the backslash survives into find's arguments. They are
  now quoted (`'!'`, `'('`, `')'`) in both the Makefile and the script's
  own prune expression.
- `get_version.sh` runs at Makefile-parse time through `$(shell)`, so it
  cannot take the macOS gsed/ggrep overrides — its expressions are now
  POSIX in their own right (`grep -E`, sed `\{1,\}`).
- `gen_mk.sh` falls back to `tr` where `column(1)` is absent; the
  generated rules lose alignment but stay valid Make.
- A new `.gitattributes` normalises every text file to LF, so the
  Windows checkout matches `.editorconfig` and the tidy diff check does
  not trip over CRLF.

## markdownlint-cli2

`build: upgrade markdownlint-cli to markdownlint-cli2` moves detection
and invocation to the actively developed CLI. cli2 has no `--version`
flag, so detection probes the `--help` banner on stdout. Flags and the
`markdownlint.json` config carry over unchanged.

## Tidy on the platform runners

`ci: run make tidy on the platform runners` reuses the macOS and
Windows test boxes: each cell runs `make tidy` — the linter version is
selected per Go version, so each tier enforces its own rules — then
`git diff --exit-code` fails, printing the patch, on anything left
behind. This keeps `make tidy` runnable natively on macOS and Windows,
so a contributor on either platform can run the gate locally.

## Verification

Green locally and on all three workflows. The Platforms run exercised
the new tidy step on every macOS and Windows cell — the first CI proof
of the BSD `stat` arm, the quoted find operators on Windows, and the
CRLF normalisation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Development**
  * Improved build tooling compatibility across GNU, BSD/macOS and minimal environments.
  * Enhanced whitespace and file-format handling while preserving file permissions.
  * Improved version detection and generated build-file formatting.

* **Quality Assurance**
  * Added automated checks to ensure formatting and tidy operations leave no unintended repository changes.
  * Updated Markdown lint tool detection for improved reliability.

* **Consistency**
  * Standardised text files to use LF line endings across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->